### PR TITLE
fix: bootstrap nvm in production deploy shells

### DIFF
--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -63,12 +63,15 @@ flowchart TD
    - `npm run test:smoke`
 4. `verify`가 끝나면 workflow가 검증된 commit SHA를 고정한다.
 5. `deploy` job이 시작되면 OCI 서버에 SSH 접속해서 아래를 수행한다.
+   - 비대화형 SSH 셸에서도 `nvm` 경로를 사용할 수 있도록 원격 스크립트가 `NVM_DIR`과 `nvm.sh`를 직접 로드한다.
+   - `node`, `npm`, `pm2`가 현재 원격 셸에서 보이지 않으면 fail-fast로 중단한다.
    - `git fetch origin --tags`
    - 검증된 commit SHA를 `git checkout --detach --force`로 정확히 checkout
    - `npm ci`
    - `npm run build`
    - PM2 프로세스 reload 또는 최초 start
 6. `Verify production readiness` 단계에서 아래를 자동 확인한다.
+   - 비대화형 SSH 셸에서 `nvm` bootstrap 후 `node`, `pm2`를 사용할 수 있는지
    - PM2에 같은 이름의 online 프로세스가 1개인지
    - 이번 배포 이후 info 로그에 새 `Ready! Logged in as`가 기록됐는지
 

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -49,6 +49,16 @@ metadata_dir="${app_dir}/runtime"
 metadata_path="${metadata_dir}/production-deployment-metadata.env"
 info_log_pattern='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].log'
 
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "${NVM_DIR}/nvm.sh" ]]; then
+  # shellcheck disable=SC1090
+  source "${NVM_DIR}/nvm.sh"
+fi
+
+command -v node >/dev/null || { echo "node not found in remote deployment shell" >&2; exit 1; }
+command -v npm >/dev/null || { echo "npm not found in remote deployment shell" >&2; exit 1; }
+command -v pm2 >/dev/null || { echo "pm2 not found in remote deployment shell" >&2; exit 1; }
+
 cd "${app_dir}"
 mkdir -p "${metadata_dir}" logs
 

--- a/scripts/verify-production-readiness.sh
+++ b/scripts/verify-production-readiness.sh
@@ -50,6 +50,15 @@ ready_log_pattern="$4"
 metadata_path="${app_dir}/runtime/production-deployment-metadata.env"
 info_log_pattern='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].log'
 
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "${NVM_DIR}/nvm.sh" ]]; then
+  # shellcheck disable=SC1090
+  source "${NVM_DIR}/nvm.sh"
+fi
+
+command -v node >/dev/null || { echo "node not found in remote readiness shell" >&2; exit 1; }
+command -v pm2 >/dev/null || { echo "pm2 not found in remote readiness shell" >&2; exit 1; }
+
 cd "${app_dir}"
 
 if [[ ! -f "${metadata_path}" ]]; then

--- a/src/test/US-15-production-delivery-workflow.test.ts
+++ b/src/test/US-15-production-delivery-workflow.test.ts
@@ -51,6 +51,11 @@ describe('US-15 production delivery workflow', () => {
     const script = readRepositoryFile('scripts/deploy-production.sh');
 
     expect(script).toContain('PRODUCTION_GIT_SHA');
+    expect(script).toContain('export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"');
+    expect(script).toContain('source "${NVM_DIR}/nvm.sh"');
+    expect(script).toContain('command -v node >/dev/null');
+    expect(script).toContain('command -v npm >/dev/null');
+    expect(script).toContain('command -v pm2 >/dev/null');
     expect(script).toContain('git fetch origin --tags');
     expect(script).toContain('git checkout --detach');
     expect(script).not.toContain('git pull --ff-only origin');
@@ -62,6 +67,10 @@ describe('US-15 production delivery workflow', () => {
     expect(script).toContain('PRODUCTION_SSH_KNOWN_HOSTS');
     expect(script).toContain('StrictHostKeyChecking=yes');
     expect(script).toContain('UserKnownHostsFile');
+    expect(script).toContain('export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"');
+    expect(script).toContain('source "${NVM_DIR}/nvm.sh"');
+    expect(script).toContain('command -v node >/dev/null');
+    expect(script).toContain('command -v pm2 >/dev/null');
     expect(script).toContain('deployment-metadata');
     expect(script).toContain('current_info_log_file="$(latest_info_log_file)"');
     expect(script).toContain('grep -F "${ready_log_pattern}" "${current_info_log_file}"');


### PR DESCRIPTION
## 연관된 이슈

- closes #54
- refs #33

## 작업 내용

- `scripts/deploy-production.sh` 원격 heredoc 초반에 `NVM_DIR`/`nvm.sh` bootstrap을 추가해 비대화형 SSH 셸에서도 `node`, `npm`, `pm2`를 찾도록 보강했습니다.
- `scripts/verify-production-readiness.sh`에도 같은 `nvm` bootstrap과 `node`/`pm2` fail-fast 검증을 추가했습니다.
- `src/test/US-15-production-delivery-workflow.test.ts`를 확장해 deploy/readiness 스크립트가 `nvm` bootstrap과 `command -v` 검증을 포함하는지 정적으로 검증하도록 만들었습니다.
- `docs/PRODUCTION_RUNBOOK.md`에 deploy/readiness 단계가 비대화형 SSH 셸에서 `nvm`을 직접 로드하고, 필수 바이너리가 보이지 않으면 fail-fast로 중단한다는 운영 메모를 반영했습니다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
  B1[Before: remote bash -s shell starts without nvm bootstrap] --> B2[npm/pm2 may be missing from PATH]
  B2 --> B3[deploy fails at npm ci]

  A1[After: remote deploy/readiness shell starts] --> A2[load NVM_DIR and source nvm.sh]
  A2 --> A3[verify node/npm/pm2 with command -v]
  A3 --> A4[run deploy or readiness steps]
```

## 이번 PR 범위

- 포함:
  - deploy/readiness 원격 셸의 `nvm` bootstrap 보강
  - `US-15` 정적 계약 테스트 보강
  - production runbook 보강
- 제외:
  - 테스트 길드 슬래시 커맨드 미재등록으로 실패하는 `integration-test` 수정
  - production 서버의 system-wide Node 설치 강제
  - deploy workflow trigger/policy 변경

## 문서 영향

- 업데이트한 문서:
  - `docs/PRODUCTION_RUNBOOK.md`
- 업데이트하지 않은 문서:
  - `docs/PROJECT.md`
    - 이유: 이번 변경은 production deploy/readiness 스크립트의 원격 셸 bootstrap 보강으로 한정되고, 프로젝트 구조나 사용자/운영 흐름 자체는 바뀌지 않아 runbook 반영만으로 충분합니다.
  - `docs/USER_STORIES.md`
    - 이유: 사용자 기능/시나리오 변화가 없습니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- 구현 및 정적 검증으로 반영:
  - production deploy script가 비대화형 SSH 셸에서도 `node`, `npm`, `pm2`를 사용할 수 있도록 `nvm` bootstrap과 fail-fast 검증을 포함함
  - production readiness script가 비대화형 SSH 셸에서도 `node`, `pm2`를 사용할 수 있도록 `nvm` bootstrap과 fail-fast 검증을 포함함
  - 관련 정적 테스트가 새 계약을 검증함
  - runbook이 현재 배포 스크립트 전제조건과 일치함
- 아직 수동 검증이 남은 항목:
  - 실제 production 서버에서 `Deploy Production` workflow를 다시 실행해 `npm: command not found`가 재현되지 않는지 확인

## 추가/수정된 테스트 명세

- `src/test/US-15-production-delivery-workflow.test.ts`
  - red: deploy/readiness 스크립트에 `nvm` bootstrap과 `command -v` 계약이 없어서 실패
  - green: 두 스크립트에 `NVM_DIR`, `nvm.sh`, 바이너리 fail-fast 검증을 추가한 뒤 통과

## 로컬 검증 결과

- PASS: `npx vitest run src/test/US-15-production-delivery-workflow.test.ts`
- PASS: `npx -p node@20.20.2 -p npm@10 npm run local:ci`
  - `npm run lint`
  - `npx prettier --check src`
  - `npm run build`
  - `npm test`
- 참고:
  - 작업 머신 기본 Node는 `v25.8.1`이라 `sqlite3` 빌드 문제가 있어, GitHub Actions와 동일한 Node 20으로 로컬 CI를 실행했습니다.

## 사용자 승인으로 처리한 범위 이탈 내역

- 없음

## 체크리스트

- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 이슈 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
