### PR TITLE
fix: production readiness new-log false negative

### DIFF
--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -84,6 +84,13 @@ flowchart TD
    - 비대화형 SSH 셸에서 `nvm` bootstrap 후 `node`, `pm2`를 사용할 수 있는지
    - PM2에 같은 이름의 online 프로세스가 1개인지
    - 이번 배포 이후 info 로그에 새 `Ready! Logged in as`가 기록됐는지
+   - 직전 배포와 같은 일별 info 로그 파일을 재사용하면 이전 배포 시점의 바이트 오프셋 뒤만 검사하고, 새 일별 info 로그 파일이 생기면 새 파일 전체에서 ready 로그를 검사한다
+
+### Readiness 로그 판정 메모
+
+- readiness 스크립트는 `runtime/production-deployment-metadata.env`의 `PREVIOUS_INFO_LOG_FILE`, `PREVIOUS_INFO_LOG_SIZE`를 읽어 이번 배포 이후에 추가된 ready 로그만 본다.
+- 새 로그 파일이 생성된 배포에서는 이전 오프셋을 이어서 쓰지 않고, 최신 info 로그 파일 전체에서 `Ready! Logged in as`를 찾는다.
+- 2026-03-29 이전에는 새 로그 파일 분기 반환값 버그 때문에 ready 로그가 있어도 `Could not find a new ready log entry for haruharu-bot` false negative가 날 수 있었다. 같은 증상이 다시 보이면 스크립트 버전과 최근 배포 시점 로그 파일 교체 여부를 먼저 확인한다.
 
 ## 배포 후 수동 검증
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -305,6 +305,9 @@ flowchart TD
   I --> J[Manual /ping if needed]
 ```
 
+- `scripts/verify-production-readiness.sh`는 `runtime/production-deployment-metadata.env`를 읽어 직전 배포가 본 info 로그 파일과 바이트 오프셋을 복원한다.
+- 같은 일별 info 로그 파일을 재사용하면 이전 오프셋 뒤에서만 `Ready! Logged in as`를 찾고, 새 일별 info 로그 파일이 생기면 새 파일 전체를 검사한다.
+
 #### interactionCreate.ts
 
 | 항목   | 내용                                                                   |

--- a/scripts/verify-production-readiness.sh
+++ b/scripts/verify-production-readiness.sh
@@ -117,7 +117,7 @@ find_new_ready_log_entry() {
 
   grep -F "${ready_log_pattern}" "${current_info_log_file}" >/dev/null
 
-  return 1
+  return $?
 }
 
 latest_info_log_file() {

--- a/src/test/US-15-production-delivery-workflow.test.ts
+++ b/src/test/US-15-production-delivery-workflow.test.ts
@@ -1,4 +1,6 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -35,6 +37,63 @@ const expectWorkflowJobRuntime = (
 
   if (options?.nodeVersion) {
     expect(jobBlock).toContain(`node-version: '${options.nodeVersion}'`);
+  }
+};
+
+const extractShellFunction = (script: string, functionName: string) => {
+  const match = script.match(new RegExp(`^${escapeRegExp(functionName)}\\(\\) \\{[\\s\\S]*?^\\}`, 'm'));
+
+  expect(match, `Failed to extract ${functionName} from readiness script`).not.toBeNull();
+
+  return match![0];
+};
+
+const runReadinessDetectionScenario = (options: {
+  currentLogFileName: string;
+  currentLogContent: string;
+  previousLogFileName?: string;
+  previousLogContent?: string;
+  previousInfoLogFile?: string;
+  previousInfoLogSize?: number;
+}) => {
+  const script = readRepositoryFile('scripts/verify-production-readiness.sh');
+  const harness = [
+    'set -euo pipefail',
+    extractShellFunction(script, 'find_new_ready_log_entry'),
+    extractShellFunction(script, 'latest_info_log_file'),
+    'if find_new_ready_log_entry; then',
+    '  exit 0',
+    'fi',
+    'exit 1',
+  ].join('\n\n');
+
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'haruharu-readiness-'));
+  const logsDirectory = path.join(tempDirectory, 'logs');
+
+  try {
+    fs.mkdirSync(logsDirectory);
+
+    if (options.previousLogFileName && options.previousLogContent !== undefined) {
+      fs.writeFileSync(path.join(logsDirectory, options.previousLogFileName), options.previousLogContent);
+    }
+
+    fs.writeFileSync(path.join(logsDirectory, options.currentLogFileName), options.currentLogContent);
+
+    return spawnSync('bash', ['-lc', harness], {
+      cwd: tempDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        info_log_pattern: '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].log',
+        ready_log_pattern: 'Ready! Logged in as',
+        ...(options.previousInfoLogFile ? { PREVIOUS_INFO_LOG_FILE: options.previousInfoLogFile } : {}),
+        ...(options.previousInfoLogSize !== undefined
+          ? { PREVIOUS_INFO_LOG_SIZE: String(options.previousInfoLogSize) }
+          : {}),
+      },
+    });
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
   }
 };
 
@@ -189,6 +248,31 @@ describe('US-15 production delivery workflow', () => {
     expect(script).not.toContain('grep -F "${ready_log_pattern}" "${candidate}"');
     expect(script).not.toContain("find logs -maxdepth 1 -type f -name '*.log'");
     expect(script).not.toContain('xargs ls -t');
+  });
+
+  it('readiness helper는 새 info 로그 파일에서 ready 로그를 찾으면 성공해야 한다', () => {
+    const result = runReadinessDetectionScenario({
+      previousLogFileName: '2026-03-28.log',
+      previousLogContent: '{"message":"older deployment"}\n',
+      previousInfoLogFile: 'logs/2026-03-28.log',
+      previousInfoLogSize: Buffer.byteLength('{"message":"older deployment"}\n'),
+      currentLogFileName: '2026-03-29.log',
+      currentLogContent: '{"message":"Ready! Logged in as HaruHaru"}\n',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it('readiness helper는 같은 info 로그 파일 재사용 시 이전 바이트 오프셋 이전의 ready 로그를 무시해야 한다', () => {
+    const previousSegment = '{"message":"Ready! Logged in as old deployment"}\n';
+    const result = runReadinessDetectionScenario({
+      previousInfoLogFile: 'logs/2026-03-29.log',
+      previousInfoLogSize: Buffer.byteLength(previousSegment),
+      currentLogFileName: '2026-03-29.log',
+      currentLogContent: `${previousSegment}{"message":"after deploy but not ready"}\n`,
+    });
+
+    expect(result.status, result.stderr).toBe(1);
   });
 
   it('runbook은 known_hosts와 verified sha 기반 배포 흐름을 설명해야 한다', () => {


### PR DESCRIPTION
## 연관된 이슈

- closes #66
- refs #66

## 작업 내용

- `scripts/verify-production-readiness.sh`의 새 info 로그 파일 분기에서 `grep` 결과를 그대로 반환하도록 수정했습니다.
- `src/test/US-15-production-delivery-workflow.test.ts`에 readiness helper 실행형 회귀 테스트를 추가해 새 로그 파일 false negative와 기존 로그 파일 바이트 오프셋 동작을 함께 고정했습니다.
- `docs/PRODUCTION_RUNBOOK.md`, `docs/PROJECT.md`를 현재 readiness 판정 기준과 2026-03-29 false negative 원인에 맞게 동기화했습니다.

## 변경 흐름 (Mermaid)

- mermaid 생략: 배포 구조나 실행 흐름 자체는 바뀌지 않았고, 기존 readiness 분기 반환값 버그만 수정했습니다.

## 이번 PR 범위

- 포함:
  - readiness 스크립트 새 로그 파일 분기 반환값 수정
  - readiness 회귀 테스트 추가
  - 운영 문서 동기화
- 제외:
  - PM2 프로세스 구조 변경
  - Discord ready 이벤트 로깅 방식 변경
  - production deploy artifact 생성 로직 변경

## 문서 영향

- 업데이트함:
  - `docs/PRODUCTION_RUNBOOK.md`: readiness가 같은 로그 파일이면 이전 바이트 오프셋 뒤만 보고, 새 로그 파일이면 파일 전체를 본다는 점과 false negative 원인을 추가했습니다.
  - `docs/PROJECT.md`: production readiness 스크립트가 metadata 기반으로 로그 파일/오프셋을 복원하는 방식을 추가했습니다.
- 업데이트하지 않음:
  - `AGENTS.md`: 배포/검증 절차의 상위 규칙과 저장소 구조는 그대로라서 고수준 작업 기준은 바뀌지 않았습니다.
  - `docs/USER_STORIES.md`: 사용자 기능/흐름 변화가 없습니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- 완료조건
  - [x] 새 info 로그 파일에서 `Ready! Logged in as`가 발견되면 readiness 스크립트가 성공으로 종료합니다.
  - [x] 기존 info 로그 파일 재사용 시에도 이전 배포 이후 바이트 오프셋 기준 탐지가 유지됩니다.
  - [x] readiness 회귀 테스트가 새 로그 파일 분기 false negative를 재현하고 수정 후 green 입니다.
  - [x] 관련 운영 문서가 현재 readiness 판정 동작과 실패 원인을 설명합니다.
- red -> green
  - [x] `src/test/US-15-production-delivery-workflow.test.ts`의 새 로그 파일 시나리오를 먼저 추가했고, 수정 전에는 exit status `1`로 실패하는 red를 확인했습니다.
  - [x] 스크립트 수정 후 같은 테스트 파일이 green 으로 통과함을 확인했습니다.
- 회귀 테스트
  - [x] 새 로그 파일 분기에서 ready 로그가 있으면 성공하는 시나리오를 실행형 테스트로 고정했습니다.
  - [x] 같은 로그 파일 재사용 분기에서 이전 바이트 오프셋 이전의 ready 로그는 무시하는 시나리오를 실행형 테스트로 고정했습니다.
  - [x] helper 추출 대신 실제 스크립트 함수 본문을 테스트에서 추출해 bash로 실행했습니다.

## 추가된 테스트 명세

- 새 일별 info 로그 파일이 생성된 배포에서 `Ready! Logged in as`가 포함되면 `find_new_ready_log_entry()`가 성공을 반환해야 합니다.
- 같은 일별 info 로그 파일을 재사용하는 배포에서는 `PREVIOUS_INFO_LOG_SIZE` 이전에 있던 ready 로그만으로는 성공하면 안 됩니다.

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 있다면 PR 본문에 단일 `mermaid` 블록과 최상위 `Before: ...` / `After: ...` 박스를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 검증
  - `npm run lint` 상당: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run lint`
  - `npx prettier --check src` 상당: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npx-cli.js prettier --check src`
  - `npm run build` 상당: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build`
  - 이슈 대상 회귀 테스트: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js test -- src/test/US-15-production-delivery-workflow.test.ts`
  - 전체 unit test: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js test`
  - smoke test: `npx -y node@24 /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run test:smoke`
- GitHub Actions `Verify production readiness` 재실행은 이 로컬 작업에서는 수행하지 않았습니다.
- 로컬 설치는 Node 24 + `npm_config_python=$PWD/.node-gyp-venv/bin/python`으로 맞춰 `sqlite3` 빌드를 통과시켰습니다.
