### PR TITLE
fix: simplify daily attendance message copy

### DIFF
--- a/src/commands/haruharu/demo-daily-message.ts
+++ b/src/commands/haruharu/demo-daily-message.ts
@@ -7,6 +7,7 @@ import {
   ThreadAutoArchiveDuration,
 } from 'discord.js';
 import { testChannelId } from '../../config.js';
+import { buildDailyAttendanceMessageContent } from '../../daily-attendance.js';
 import { pickDailyMessageQuestion } from '../../daily-message.js';
 import { logger } from '../../logger.js';
 import { getYearMonthDate, PERMISSION_NUM_ADMIN } from '../../utils.js';
@@ -22,19 +23,6 @@ const findExistingThread = async (channel: TextChannel, threadName: string) => {
 
   const archivedThreads = await channel.threads.fetchArchived();
   return archivedThreads.threads.find(thread => thread.name === threadName) ?? null;
-};
-
-const buildDailyMessageContent = (year: number, month: string, date: string, question: string) => {
-  return [
-    `[🌅 ${year}-${month}-${date}]`,
-    '',
-    '오늘의 한마디:',
-    '"완벽하려고 하지 말고, 시작하자."',
-    '',
-    '👉 오늘 목표 하나만 적고 시작해보세요',
-    `📝 오늘의 질문: ${question}`,
-    '👇 반드시 아래 쓰레드에서 오늘 출석을 남겨주세요',
-  ].join('\n');
 };
 
 export const command = {
@@ -80,7 +68,7 @@ export const command = {
         };
       }
 
-      const dailyMessage = await testChannel.send(buildDailyMessageContent(year, month, date, question));
+      const dailyMessage = await testChannel.send(buildDailyAttendanceMessageContent(year, month, date, question));
       const thread = await dailyMessage.startThread({
         name: threadName,
         autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,

--- a/src/daily-attendance.ts
+++ b/src/daily-attendance.ts
@@ -14,12 +14,10 @@ const buildDailyAttendanceMessageContent = (year: number, month: string, date: s
   return [
     `[🌅 ${year}-${month}-${date}]`,
     '',
-    '오늘의 한마디:',
-    '"완벽하려고 하지 말고, 시작하자."',
+    '오늘의 질문:',
+    `"${question}"`,
     '',
-    '👉 오늘 목표 하나만 적고 시작해보세요',
-    `📝 오늘의 질문: ${question}`,
-    '👇 반드시 아래 쓰레드에서 오늘 출석을 남겨주세요',
+    '👇 아래 쓰레드에 오늘 출석과 함께 답변을 남겨주세요',
   ].join('\n');
 };
 

--- a/src/test/US-12-daily-message-demo.test.ts
+++ b/src/test/US-12-daily-message-demo.test.ts
@@ -103,7 +103,10 @@ describe('US-12: daily message 데모', () => {
 
     expect(fetch).toHaveBeenCalledWith('valid-test-channel-id');
     expect(send).toHaveBeenCalledOnce();
-    expect(send.mock.calls[0]?.[0]).toContain('📝 오늘의 질문: 오늘 꼭 이루고 싶은 한 가지는 무엇인가요?');
+    expect(send.mock.calls[0]?.[0]).toContain('오늘의 질문:');
+    expect(send.mock.calls[0]?.[0]).toContain('"오늘 꼭 이루고 싶은 한 가지는 무엇인가요?"');
+    expect(send.mock.calls[0]?.[0]).toContain('👇 아래 쓰레드에 오늘 출석과 함께 답변을 남겨주세요');
+    expect(send.mock.calls[0]?.[0]).not.toContain('오늘의 한마디:');
     expect(startThread).toHaveBeenCalledOnce();
     expect(threadSend).toHaveBeenCalledOnce();
     expect(interaction.getLastReply()).toContain('데모 출석 메시지와 쓰레드를 생성했습니다');

--- a/src/test/US-13-daily-message-automation.test.ts
+++ b/src/test/US-13-daily-message-automation.test.ts
@@ -122,6 +122,9 @@ describe('US-13: 운영 daily message 자동화', () => {
     expect(fetch).toHaveBeenCalledWith('valid-channel-id');
     expect(send).toHaveBeenCalledOnce();
     expect(send.mock.calls[0]?.[0]).toContain('[🌅 2026-03-29]');
+    expect(send.mock.calls[0]?.[0]).toContain('오늘의 질문:');
+    expect(send.mock.calls[0]?.[0]).toContain('👇 아래 쓰레드에 오늘 출석과 함께 답변을 남겨주세요');
+    expect(send.mock.calls[0]?.[0]).not.toContain('오늘의 한마디:');
     expect(startThread).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '2026-03-29 출석',


### PR DESCRIPTION
## 연관된 이슈

- closes #81
- refs #79

## 작업 내용

- 운영 daily message 본문에서 `오늘의 한마디`를 제거했습니다.
- 질문 텍스트를 `오늘의 질문` 섹션 상단으로 올리고 질문 내용을 직접 노출하도록 바꿨습니다.
- 안내 문구를 `아래 쓰레드에 오늘 출석과 함께 답변을 남겨주세요`로 수정했습니다.
- `/demo-daily-message`가 운영 자동화와 동일한 본문 생성 함수를 재사용하도록 정리했습니다.
- 관련 테스트의 문자열 기대값을 새 카피 기준으로 갱신했습니다.

## 변경 흐름 (Mermaid)

- 구조, 실행 흐름, 데이터 흐름 변경이 아니라 daily message 카피 조정이어서 `mermaid`는 생략했습니다.

## 이번 PR 범위

- 운영/데모 daily message 본문 카피 수정
- 운영/데모가 동일한 본문 포맷을 쓰도록 메시지 생성 함수 재사용
- 관련 테스트 기대값 갱신

제외:
- daily message 생성 스케줄/백필 정책 변경
- 출석 판정 규칙 변경
- thread 안내 메시지 변경
- DB 스키마/이벤트 흐름 변경

## 문서 영향

- 문서 변경 없음
- 이유: 구조, 실행 흐름, 슬래시 커맨드, 이벤트, DB 스키마, 테스트 방식은 바뀌지 않고 daily message 본문 카피만 조정했습니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- `오늘의 한마디` 제거를 반영했습니다.
- 질문 텍스트가 `오늘의 질문` 섹션에 직접 노출되도록 반영했습니다.
- 안내 문구를 thread에 `오늘 출석과 함께 답변`을 남기도록 수정했습니다.
- `/demo-daily-message`와 운영 자동화가 동일한 본문 포맷을 사용하도록 맞췄습니다.
- 관련 테스트를 새 문구 기준으로 갱신했습니다.
- 이슈의 회귀 테스트 계획에 맞춰 `US-12`, `US-13` 기대값을 문자열 기준으로 고정했습니다.

## 추가된 테스트 명세

- `src/test/US-12-daily-message-demo.test.ts`
  - 데모 커맨드가 `오늘의 질문` 헤더, 따옴표 포함 질문 본문, `출석과 함께 답변` 안내 문구를 포함하는지 검증합니다.
  - 기존 `오늘의 한마디` 문구가 더 이상 포함되지 않는지 검증합니다.
- `src/test/US-13-daily-message-automation.test.ts`
  - 운영 daily message 자동화가 동일한 새 카피를 사용하는지 검증합니다.
  - 기존 `오늘의 한마디` 문구가 더 이상 포함되지 않는지 검증합니다.

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 있다면 PR 본문에 단일 `mermaid` 블록과 최상위 `Before: ...` / `After: ...` 박스를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 검증
  - `npm run lint`
  - `npx prettier --check src`
  - `npm run build`
  - `npm test`
