### PR TITLE
fix: /register raw query 운영 실패 수정

### DIFF
--- a/src/repository/config.ts
+++ b/src/repository/config.ts
@@ -8,7 +8,6 @@ const sequelize = new Sequelize('haruharu-database', databaseUser, password, {
   // logQueryParameters: true,
   logging: false,
   storage: 'database.sqlite',
-  query: { raw: true },
 });
 
 export { sequelize, Sequelize, DataType };

--- a/src/services/challengeSelfService.ts
+++ b/src/services/challengeSelfService.ts
@@ -13,6 +13,7 @@ import {
   listActiveWakeUpMemberships,
   listChallengeUserExclusions,
   listWakeUpMembershipsByUserIds,
+  updateChallengeUser,
   updateWakeUpMembership,
 } from '../repository/challengeRepository.js';
 import { isValidWakeTime } from '../attendance.js';
@@ -73,7 +74,7 @@ const createChallengeUserSnapshot = async ({
   });
 
   if (!created && (user.username !== username || user.waketime !== waketime)) {
-    await user.update({ username, waketime });
+    await updateChallengeUser(userId, yearmonth, { username, waketime });
   }
 
   return [user, created] as const;
@@ -242,7 +243,7 @@ const executeRegister = async ({
   }
 
   await createWaketimeChangeLog({ userid: userId, yearmonthday, waketime });
-  await user.update({ username, waketime });
+  await updateChallengeUser(userId, yearmonth, { username, waketime });
 
   return { reply: `${username}님 기상시간을 수정했습니다. 기준월: ${yearmonth}, 기상시간: ${waketime}` };
 };

--- a/src/test/US-01-register.test.ts
+++ b/src/test/US-01-register.test.ts
@@ -110,4 +110,47 @@ describe('US-01: /register 커맨드', () => {
     expect(user?.waketime).toBe('0700');
     expect(interaction.getLastReply()).toContain('하루에 한 번만');
   });
+
+  it('TC-R04: repository 조회 결과가 plain object 여도 기존 사용자 기상시간을 수정할 수 있다', async () => {
+    await TestUsers.create({
+      userid: 'existing-user',
+      username: '홍길동',
+      yearmonth: '202512',
+      waketime: '0700',
+      vacances: 5,
+      latecount: 0,
+      absencecount: 0,
+    });
+
+    const existingUser = await TestUsers.findOne({
+      where: { userid: 'existing-user', yearmonth: '202512' },
+    });
+
+    const findOneSpy = vi.spyOn(TestUsers, 'findOne').mockImplementation(async options => {
+      const where = (options as { where?: { userid?: string; yearmonth?: string } } | undefined)?.where;
+      if (where?.userid === 'existing-user' && where?.yearmonth === '202512') {
+        return existingUser?.get({ plain: true }) as never;
+      }
+
+      return null as never;
+    });
+
+    const interaction = createMockInteraction({
+      userId: 'existing-user',
+      globalName: '홍길동',
+      options: {
+        waketime: '0800',
+      },
+    });
+
+    const { command } = await import('../commands/haruharu/register.js');
+
+    await command.execute(interaction as never);
+
+    findOneSpy.mockRestore();
+
+    const updatedUser = await TestUsers.findOne({ where: { userid: 'existing-user', yearmonth: '202512' } });
+    expect(updatedUser?.waketime).toBe('0800');
+    expect(interaction.getLastReply()).toContain('수정했습니다');
+  });
 });

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -143,6 +143,39 @@ describe('config.ts', () => {
     });
   });
 
+  it('repository sequelize 설정은 model instance 메서드를 깨뜨리는 global raw query를 사용하지 않는다', async () => {
+    vi.doMock('node:module', async importOriginal => {
+      const original = await importOriginal<typeof import('node:module')>();
+      return {
+        ...original,
+        createRequire: () => (path: string) => {
+          if (path.includes('config.json')) {
+            return {
+              token: 'token',
+              clientId: 'client-id',
+              guildId: 'guild-id',
+              checkChannelId: 'check-channel',
+              testChannelId: 'test-channel',
+              logChannelId: 'log-channel',
+              resultChannelId: 'result-channel',
+              voiceChannelId: 'voice-channel',
+              startHereChannelId: 'start-here-channel',
+              timeStartHereChannelId: 'time-start-here-channel',
+              wakeUpRoleId: 'wake-up-role',
+              camStudyRoleId: 'cam-study-role',
+            };
+          }
+
+          return original.createRequire(import.meta.url)(path);
+        },
+      };
+    });
+
+    const { sequelize } = await import('../repository/config.js');
+
+    expect(sequelize.options.query?.raw).not.toBe(true);
+  });
+
   it('command deploy 경로는 opsChannelId 없이도 command payload 로딩에 성공한다', async () => {
     vi.doMock('node:module', async importOriginal => {
       const original = await importOriginal<typeof import('node:module')>();


### PR DESCRIPTION
## 연관된 이슈

- closes #85
- refs #85

## 작업 내용

- `/register` 기존 사용자 수정 경로를 model instance 메서드 의존에서 repository 정적 update 호출로 변경했습니다.
- 운영 Sequelize 설정에서 global `query.raw = true` 를 제거해 운영/테스트 반환 형태 차이를 없앴습니다.
- plain object 반환 상황과 repository 설정 drift를 각각 고정하는 회귀 테스트를 추가했습니다.

## 변경 흐름 (Mermaid)

- 생략: ORM 설정/업데이트 경로만 수정한 작은 버그 수정이라 구조, 실행 흐름, 데이터 흐름 자체는 바뀌지 않았습니다.

## 이번 PR 범위

- 포함:
  - `/register` 기존 사용자 수정 실패 원인 제거
  - Sequelize global raw query 설정 제거
  - 회귀 테스트 추가
- 제외:
  - Discord privileged intent(`Used disallowed intents`) 이슈 해결
  - 슬래시 커맨드 정책, 이벤트 흐름, DB 스키마 변경
  - 배포/운영 문서 절차 변경

## 문서 영향

- 업데이트 불필요:
  - 이유: 슬래시 커맨드 인터페이스, 이벤트 흐름, DB 스키마, 운영 절차 변경이 아니라 ORM 설정 버그 수정과 회귀 테스트 보강입니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- 완료조건
  - [x] `/register` 기존 사용자 수정 경로가 Sequelize model instance 메서드에 의존하지 않습니다.
  - [x] 운영 Sequelize 설정에 global `query.raw = true` 가 남아 있지 않습니다.
  - [x] plain object 반환 상황을 재현하는 회귀 테스트를 추가했습니다.
  - [x] 운영/테스트 설정 drift를 검증하는 테스트를 추가했습니다.
  - [x] `npm run lint`, `npx prettier --check src`, `npm run build`, `npm test` 를 모두 통과했습니다.
- red -> green 확인
  - [x] `src/test/US-01-register.test.ts` 의 plain object 반환 회귀 테스트를 먼저 실패시킨 뒤 green 확인
  - [x] `src/test/config.test.ts` 의 global raw query 금지 테스트를 먼저 실패시킨 뒤 green 확인
- 회귀 테스트 계획
  - [x] `npx vitest run src/test/US-01-register.test.ts`
  - [x] `npx vitest run src/test/config.test.ts`
  - [x] `npm test`
  - [ ] 운영 서버에서 동일 재현 시 성공 응답 수동 확인

## 추가된 테스트 명세

- `TC-R04`: repository 조회 결과가 plain object 여도 `/register` 기존 사용자 기상시간 수정이 성공해야 한다.
- repository sequelize 설정은 model instance 메서드를 깨뜨리는 global raw query를 사용하지 않아야 한다.

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 없다면 mermaid 생략 이유를 적었나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] AGENTS.md 업데이트가 필요한 변경인지 점검했고, 이번 변경은 문서 갱신 대상이 아님을 확인했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 운영 로그 재현:
  - `2026-03-29 22:39:56 KST`
  - `TypeError: user.update is not a function`
