### PR TITLE
fix: stop wakeup immediately for current month

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@
 - 사용자 self-service 명령은 `interaction.user.id`를 기준으로 자신의 데이터만 변경해야 한다.
 - 기상시간 self-service는 `/register` 하나로 기상 참여 시작/재시작과 기상시간 등록/수정을 처리하되 하루 1회 제한을 지켜야 한다.
 - `/register`, `/stop-wakeup`, `/apply-vacation`은 `#start-here`와 기상 self-service 전용 온보딩 채널에서만 실행되도록 유지한다.
-- 기상 self-service 중단은 `/stop-wakeup` 으로 처리하고, 현재 월 기록은 유지한 채 이후 월 자동 등록만 중단해야 한다.
+- 기상 self-service 중단은 `/stop-wakeup` 으로 처리하고, 현재 월 참여도 즉시 중단해야 한다.
+- `/stop-wakeup` 은 현재 월 `Users` 스냅샷을 제거하고 같은 달 exclusion 을 남겨 그 달 `/register` 재등록과 자동 복구를 막아야 한다.
 - 휴가 self-service는 총 지급량 조정이 아니라 날짜 단위 사용만 담당해야 한다.
 - 캠스터디 등록 원본은 `@cam-study` 역할과 `guildMemberUpdate` 동기화로 본다.
 - 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`)은 `testChannelId`에서만 실행되도록 유지한다.

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -185,13 +185,15 @@ haruharu-discord-bot/
 비고:
 
 - `WakeUpMembership`를 생성 또는 재활성화하고, 현재 월 `Users` 스냅샷이 없으면 자동 생성한다.
+- 같은 달에 `/stop-wakeup`으로 중단한 사용자는 다음 달부터 다시 등록할 수 있다.
 - 같은 날 두 번째 변경은 `WaketimeChangeLog`로 거부한다.
 - `#start-here`, `#time-start-here`에서만 실행 가능하다.
 
 #### `/stop-wakeup` (`/기상중단`)
 
 - 별도 파라미터 없음
-- 현재 월 기록은 유지하고, 이후 월 `Users` 자동 생성만 중단한다.
+- 현재 월 `Users` 스냅샷을 제거하고 같은 달 exclusion 을 기록해 현재 월 참여를 즉시 중단한다.
+- 같은 달에는 `/register`로 다시 참여할 수 없고, 다음 달부터 다시 등록할 수 있다.
 - `WakeUpMembership` 이 아직 없고 latest `Users` 스냅샷만 있는 legacy 참가자도 backfill 후 중단 처리한다.
 - `#start-here`, `#time-start-here`에서만 실행 가능하다.
 
@@ -399,7 +401,7 @@ flowchart TD
 | 항목   | 내용                                                                                                                                                                                                                                                                                                      |
 | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 역할   | 사용자 직접 기상 참여 시작/재시작/중단, 기상시간 등록/수정, 월 스냅샷 보장, 휴가 등록 정책 처리                                                                                                                                                                                                           |
-| 담당   | `WakeUpMembership` 생성/재활성화/중단, latest `Users` 기반 membership backfill, legacy 참가자의 `/stop-wakeup` 중단 처리, 관리자 월별 삭제 exclusion 기록, 기상시간 범위 검증, register 하루 1회 변경 제한, 현재 월 `Users` 스냅샷 생성, 현재 월 휴가 날짜 제한, 휴가 날짜 중복 방지, 잔여 휴가 한도 검증 |
+| 담당   | `WakeUpMembership` 생성/재활성화/중단, latest `Users` 기반 membership backfill, legacy 참가자의 `/stop-wakeup` 중단 처리, `/stop-wakeup` 현재 월 exclusion 기록과 스냅샷 제거, 관리자 월별 삭제 exclusion 기록, 기상시간 범위 검증, register 하루 1회 변경 제한, 같은 달 `/stop-wakeup` 재등록 차단, 현재 월 `Users` 스냅샷 생성, 현재 월 휴가 날짜 제한, 휴가 날짜 중복 방지, 잔여 휴가 한도 검증 |
 | 호출처 | `src/commands/haruharu/register.ts`, `src/commands/haruharu/stop-wakeup.ts`, `src/commands/haruharu/apply-vacation.ts`                                                                                                                                                                                    |
 
 #### participationApplication.ts
@@ -449,6 +451,7 @@ flowchart TD
 
 - `(userid)` 조합은 UNIQUE이며 기상 챌린지 참여 상태를 사용자당 1건으로 유지한다.
 - `/register`가 이 테이블을 생성하거나 `stopped -> active`로 재활성화하고, 최근 등록 기상시간을 함께 갱신한다.
+- 같은 달 `/stop-wakeup`으로 중단된 membership 은 다음 달이 되기 전까지 `/register`로 재활성화할 수 없다.
 - membership 이 아직 없는 레거시 운영 데이터는 최신 `Users.yearmonth` 스냅샷을 기준으로 자동 backfill 된다.
 - 일일 리포트와 휴가 self-service는 활성 membership의 현재 월 `Users` 스냅샷을 필요 시 자동 생성한다.
 
@@ -470,7 +473,7 @@ flowchart TD
 - `(userid, yearmonth)` 조합은 UNIQUE이며 같은 월 스냅샷 중복 생성을 막는다.
 - 활성 membership 자동 backfill 은 이 테이블과 월별 exclusion 을 함께 확인한 뒤 누락된 사용자만 생성한다.
 
-#### ChallengeUserExclusion (관리자 월별 삭제 exclusion)
+#### ChallengeUserExclusion (월별 제외 exclusion)
 
 | 컬럼      | 타입    | 설명                    |
 | --------- | ------- | ----------------------- |
@@ -481,8 +484,8 @@ flowchart TD
 비고:
 
 - `(userid, yearmonth)` 조합은 UNIQUE이며 같은 달 exclusion 중복 생성을 막는다.
-- `/delete`는 이 테이블을 기록한 뒤 `Users` 월 스냅샷을 제거한다.
-- 자동 스냅샷 생성은 이 테이블에 있는 월을 건너뛰어 관리자 삭제가 같은 달 리포트에서 되살아나지 않도록 한다.
+- `/delete`와 `/stop-wakeup`은 이 테이블을 기록한 뒤 `Users` 월 스냅샷을 제거한다.
+- 자동 스냅샷 생성은 이 테이블에 있는 월을 건너뛰어 같은 달 리포트나 self-service 경로에서 사용자가 되살아나지 않도록 한다.
 
 #### TimeLog (출석 로그)
 
@@ -710,8 +713,9 @@ flowchart TD
 - `/register`는 Discord 한국어 locale에서 `/기상등록`으로 표시된다.
 - `/register`는 같은 날 두 번째 변경을 거부한다.
 - `/register`는 현재 시각 기준 `yearmonth`를 내부에서 계산하고 현재 월 `Users` 스냅샷을 보장한다.
+- `/register`는 같은 달 `/stop-wakeup`으로 중단한 사용자의 재등록을 거부하고 다음 달부터 다시 시작하게 한다.
 - `/register`, `/stop-wakeup`, `/apply-vacation`은 `#start-here`, `#time-start-here`에서만 실행된다.
-- `/stop-wakeup`은 Discord 한국어 locale에서 `/기상중단`으로 표시되며 미래 월 자동 참여만 중단한다.
+- `/stop-wakeup`은 Discord 한국어 locale에서 `/기상중단`으로 표시되며 현재 월 참여를 즉시 중단하고 같은 달 재등록을 막는다.
 - `/delete`는 지정한 `(userid, yearmonth)`를 exclusion 으로 기록해 같은 달 자동 스냅샷 생성이 사용자를 다시 만들지 않게 한다.
 - `/apply-vacation`은 Discord 한국어 locale에서 `/휴가신청`으로 표시되며 현재 월 날짜 단위(`yyyymmdd`)로 동작한다.
 - 관리자 전용 커맨드는 Discord 한국어 locale에서 `admin-...` 접두어로 표시된다.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -252,7 +252,7 @@ sequenceDiagram
 ```
 AS A 챌린저
 I WANT TO /기상중단 명령으로 기상 챌린지 상시 참여를 직접 중단
-SO THAT 다음 달부터 자동 등록되지 않게 하고 싶다
+SO THAT 이번 달 참여를 바로 멈추고 다음 달부터만 다시 시작 여부를 결정하고 싶다
 ```
 
 **인수 조건:**
@@ -260,9 +260,10 @@ SO THAT 다음 달부터 자동 등록되지 않게 하고 싶다
 - 현재 active 상태인 사용자만 중단할 수 있다
 - `/기상중단`은 `#start-here`, 기상 self-service 안내 채널에서만 실행된다
 - `WakeUpMembership` 이 아직 없는 legacy 참가자라도 latest `Users` 스냅샷에 있으면 중단할 수 있다
-- 현재 월 `Users`, `AttendanceLog`, `VacationLog` 기록은 유지된다
+- 현재 월 `Users` 스냅샷은 즉시 제거되고 같은 달 exclusion 이 기록된다
+- 같은 달 리포트/휴가/출석 경로는 이 exclusion 을 존중해 사용자를 자동 복구하지 않는다
 - `WakeUpMembership.status` 는 `stopped` 로 바뀐다
-- 이후 월에는 `Users` 자동 생성 대상에서 제외된다
+- 같은 달에는 `/기상등록`으로 다시 참여할 수 없고, 다음 달부터 다시 등록할 수 있다
 
 ```mermaid
 sequenceDiagram
@@ -283,7 +284,9 @@ sequenceDiagram
         B-->>U: "현재 진행 중인 기상스터디 참여가 없습니다"
     else active membership 존재
         B->>DB: WakeUpMembership.status = stopped
-        B-->>U: "현재 월 기록은 유지되고 다음 달부터 자동 등록되지 않습니다"
+        B->>DB: 현재 월 exclusion 기록
+        B->>DB: 현재 월 Users 삭제
+        B-->>U: "이번 달 참여는 즉시 중단되며 다음 달부터 다시 등록할 수 있습니다"
     end
 ```
 
@@ -764,7 +767,8 @@ SO THAT 같은 명령으로 등록과 수정을 모두 처리할 수 있다
 - 본인 데이터만 수정 가능
 - 기상시간은 05:00~09:00 범위만 허용
 - 같은 날에는 한 번만 변경 가능
-- 과거에 중단한 사용자도 같은 `/기상등록`으로 현재 월 참여를 다시 시작할 수 있다
+- 이전 달에 중단한 사용자는 같은 `/기상등록`으로 다시 참여할 수 있다
+- 같은 달에 `/기상중단`한 사용자는 다음 달이 되기 전까지 `/기상등록`으로 다시 참여할 수 없다
 
 ```mermaid
 sequenceDiagram

--- a/src/commands/haruharu/delete.ts
+++ b/src/commands/haruharu/delete.ts
@@ -30,11 +30,11 @@ export const command = {
     ),
 
   async execute(interaction: ChatInputCommandInteraction) {
-    const { Users } = await import('../../repository/Users.js');
+    const { findChallengeUser, deleteChallengeUser } = await import('../../repository/challengeRepository.js');
     const { createChallengeUserExclusion } = await import('../../services/challengeSelfService.js');
     const userid = interaction.options.getString('userid')!;
     const yearmonth = interaction.options.getString('yearmonth')!;
-    const foundUser = await Users.findOne({ where: { userid, yearmonth } });
+    const foundUser = await findChallengeUser(userid, yearmonth);
 
     if (!foundUser) {
       return await interaction.reply('챌린저 삭제 실패: 존재하지 않는 회원입니다');
@@ -45,7 +45,7 @@ export const command = {
       logger.info(`delete 명령행에 입력한 값: userid: ${userid}`);
 
       await createChallengeUserExclusion(userid, yearmonth);
-      await Users.destroy({ where: { userid, yearmonth } });
+      await deleteChallengeUser(userid, yearmonth);
       await interaction.reply(`${foundUser.username}님 ${yearmonth} 챌린저 정보를 삭제했습니다`);
     } catch (e) {
       logger.error(`challenge 삭제 실패`, { e });

--- a/src/repository/challengeRepository.ts
+++ b/src/repository/challengeRepository.ts
@@ -18,10 +18,9 @@ const findChallengeUserExclusion = (userid: string, yearmonth: string) =>
 const listChallengeUserExclusions = (yearmonth: string) => ChallengeUserExclusion.findAll({ where: { yearmonth } });
 
 const createChallengeUserExclusion = (userid: string, yearmonth: string) =>
-  ChallengeUserExclusion.findOrCreate({
-    where: { userid, yearmonth },
-    defaults: { userid, yearmonth },
-  });
+  ChallengeUserExclusion.bulkCreate([{ userid, yearmonth }], { ignoreDuplicates: true });
+
+const deleteChallengeUser = (userid: string, yearmonth: string) => Users.destroy({ where: { userid, yearmonth } });
 
 const listChallengeAttendanceLogs = (yearmonthday: string) => AttendanceLog.findAll({ where: { yearmonthday } });
 
@@ -107,6 +106,7 @@ export {
   bulkCreateWakeUpMemberships,
   createWakeUpMembership,
   createWaketimeChangeLog,
+  deleteChallengeUser,
   listChallengeAttendanceLogs,
   findChallengeUser,
   findChallengeUserExclusion,

--- a/src/services/challengeSelfService.ts
+++ b/src/services/challengeSelfService.ts
@@ -5,6 +5,7 @@ import {
   createWakeUpMembership,
   createVacationLog,
   createWaketimeChangeLog,
+  deleteChallengeUser,
   findChallengeUser,
   findChallengeUserExclusion,
   findVacationLog,
@@ -207,7 +208,13 @@ const executeRegister = async ({
   const yearmonth = getYearMonth(year, month);
   const yearmonthday = `${yearmonth}${date}`;
   const membership = await findWakeUpMembership(userId);
+  const currentMonthExclusion =
+    membership?.status === 'stopped' ? await findChallengeUserExclusion(userId, yearmonth) : null;
   const user = await findChallengeUser(userId, yearmonth);
+
+  if (membership?.status === 'stopped' && currentMonthExclusion) {
+    return { reply: '이번 달에 중단한 기상스터디는 다음 달부터 다시 등록할 수 있습니다' };
+  }
 
   const existingChange = await findWaketimeChangeLog(userId, yearmonthday);
   if (existingChange) {
@@ -289,6 +296,8 @@ const executeApplyVacation = async ({ userId, yearmonthday }: { userId: string; 
 };
 
 const executeStopWakeUp = async ({ userId }: { userId: string }) => {
+  const { year, month } = getYearMonthDate();
+  const currentYearmonth = getYearMonth(year, month);
   const membership = await findWakeUpMembershipWithLegacyBackfill(userId);
   if (!membership || membership.status !== 'active') {
     return { reply: '현재 진행 중인 기상스터디 참여가 없습니다' };
@@ -298,9 +307,11 @@ const executeStopWakeUp = async ({ userId }: { userId: string }) => {
     status: 'stopped',
     stoppedat: new Date().toISOString(),
   });
+  await createChallengeUserExclusion(userId, currentYearmonth);
+  await deleteChallengeUser(userId, currentYearmonth);
 
   return {
-    reply: '기상스터디 참여를 중단했습니다. 현재 월 기록은 유지되고 다음 달부터 자동 등록되지 않습니다',
+    reply: '기상스터디 참여를 중단했습니다. 이번 달 참여는 즉시 중단되며 다음 달부터 다시 등록할 수 있습니다',
   };
 };
 

--- a/src/test/US-16-wakeup-membership.test.ts
+++ b/src/test/US-16-wakeup-membership.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  TestChallengeUserExclusion,
   TestUsers,
   TestVacationLog,
   TestWakeUpMembership,
@@ -81,7 +82,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(interaction.getLastReply()).toContain('휴가를 등록');
   });
 
-  it('TC-WM03: 중단한 사용자는 다음 달 리포트에서 자동 등록되지 않는다', async () => {
+  it('TC-WM03: /stop-wakeup 은 현재 월 참가를 즉시 중단하고 현재 월 자동 복구도 막는다', async () => {
     await TestWakeUpMembership.create({
       userid: 'stopped-user',
       username: '박민수',
@@ -92,14 +93,13 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     await TestUsers.create({
       userid: 'stopped-user',
       username: '박민수',
-      yearmonth: '202512',
+      yearmonth: '202601',
       waketime: '0700',
       vacances: 5,
       latecount: 0,
       absencecount: 0,
     });
 
-    vi.setSystemTime(new Date('2025-12-20T07:05:00Z'));
     const stopInteraction = createMockInteraction({
       userId: 'stopped-user',
       globalName: '박민수',
@@ -108,22 +108,60 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     const { command: stopCommand } = await import('../commands/haruharu/stop-wakeup.js');
     await stopCommand.execute(stopInteraction as never);
 
-    vi.setSystemTime(new Date('2026-01-08T07:05:00Z'));
     const { buildChallengeReport } = await import('../services/reporting.js');
     const { attendanceMessage } = await buildChallengeReport();
 
     const membership = await TestWakeUpMembership.findOne({ where: { userid: 'stopped-user' } });
+    const exclusion = await TestChallengeUserExclusion.findOne({
+      where: { userid: 'stopped-user', yearmonth: '202601' },
+    });
     const currentMonthUser = await TestUsers.findOne({
       where: { userid: 'stopped-user', yearmonth: '202601' },
     });
 
     expect(membership?.status).toBe('stopped');
+    expect(exclusion).not.toBeNull();
     expect(currentMonthUser).toBeNull();
     expect(attendanceMessage).not.toContain('박민수');
     expect(stopInteraction.getLastReply()).toContain('중단');
   });
 
-  it('TC-WM04: 중단 후 다시 register 하면 membership이 재활성화되고 현재 월 스냅샷이 생성된다', async () => {
+  it('TC-WM04: 같은 달에 /stop-wakeup 한 사용자는 그 달에 다시 /register 할 수 없다', async () => {
+    await TestWakeUpMembership.create({
+      userid: 'return-user',
+      username: '최민지',
+      waketime: '0700',
+      status: 'stopped',
+      stoppedat: '2026-01-08T07:05:00.000Z',
+    });
+    await TestChallengeUserExclusion.create({
+      userid: 'return-user',
+      yearmonth: '202601',
+    });
+
+    const interaction = createMockInteraction({
+      userId: 'return-user',
+      globalName: '최민지',
+      options: {
+        waketime: '0800',
+      },
+    });
+
+    const { command } = await import('../commands/haruharu/register.js');
+    await command.execute(interaction as never);
+
+    const membership = await TestWakeUpMembership.findOne({ where: { userid: 'return-user' } });
+    const currentMonthUser = await TestUsers.findOne({
+      where: { userid: 'return-user', yearmonth: '202601' },
+    });
+
+    expect(membership?.status).toBe('stopped');
+    expect(membership?.waketime).toBe('0700');
+    expect(currentMonthUser).toBeNull();
+    expect(interaction.getLastReply()).toContain('다음 달부터 다시 등록');
+  });
+
+  it('TC-WM05: 이전 달에 중단한 사용자는 다음 달에 /register 로 다시 참여할 수 있다', async () => {
     await TestWakeUpMembership.create({
       userid: 'return-user',
       username: '최민지',
@@ -154,7 +192,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(interaction.getLastReply()).toContain('등록했습니다');
   });
 
-  it('TC-WM05: 신규 /register 후 다음 달에도 자동 이월된다', async () => {
+  it('TC-WM06: 신규 /register 후 다음 달에도 자동 이월된다', async () => {
     vi.setSystemTime(new Date('2025-12-07T07:05:00Z'));
     const registerInteraction = createMockInteraction({
       userId: 'new-user',
@@ -181,7 +219,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(registerInteraction.getLastReply()).toContain('등록했습니다');
   });
 
-  it('TC-WM06: 같은 userid/yearmonth Users 스냅샷은 중복 저장되지 않는다', async () => {
+  it('TC-WM07: 같은 userid/yearmonth Users 스냅샷은 중복 저장되지 않는다', async () => {
     await TestUsers.create({
       userid: 'unique-user',
       username: '유일사용자',
@@ -205,7 +243,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     ).rejects.toThrow();
   });
 
-  it('TC-WM07: /delete로 제거된 월 스냅샷은 리포트 자동 생성으로 되살아나지 않는다', async () => {
+  it('TC-WM08: /delete로 제거된 월 스냅샷은 리포트 자동 생성으로 되살아나지 않는다', async () => {
     await TestWakeUpMembership.create({
       userid: 'deleted-user',
       username: '삭제대상',
@@ -245,7 +283,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(attendanceMessage).not.toContain('삭제대상');
   });
 
-  it('TC-WM08: membership이 없는 기존 Users 참가자도 다음 달 자동 이월 대상에 포함된다', async () => {
+  it('TC-WM09: membership이 없는 기존 Users 참가자도 다음 달 자동 이월 대상에 포함된다', async () => {
     vi.setSystemTime(new Date('2025-12-07T07:05:00Z'));
     await TestUsers.create({
       userid: 'legacy-user',
@@ -272,7 +310,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(attendanceMessage).toContain('기존참가자: 결석');
   });
 
-  it('TC-WM09: legacy Users만 있는 참가자도 첫 리포트 전 /stop-wakeup 으로 중단할 수 있다', async () => {
+  it('TC-WM10: legacy Users만 있는 참가자도 첫 리포트 전 /stop-wakeup 으로 중단할 수 있다', async () => {
     vi.setSystemTime(new Date('2025-12-20T07:05:00Z'));
     await TestUsers.create({
       userid: 'legacy-stop-user',
@@ -300,7 +338,7 @@ describe('US-16: 기상스터디 상시 참여와 중단', () => {
     expect(stopInteraction.getLastReply()).toContain('중단했습니다');
   });
 
-  it('TC-WM10: legacy Users backfill 경로는 동시 /stop-wakeup 요청에도 unique 충돌 없이 idempotent 하다', async () => {
+  it('TC-WM11: legacy Users backfill 경로는 동시 /stop-wakeup 요청에도 unique 충돌 없이 idempotent 하다', async () => {
     vi.setSystemTime(new Date('2025-12-20T07:05:00Z'));
     await TestUsers.create({
       userid: 'legacy-concurrent-user',


### PR DESCRIPTION
## 연관된 이슈

- closes #89
- refs #89

## 작업 내용

- `/stop-wakeup`이 현재 월 `Users` 스냅샷을 제거하고 같은 달 exclusion을 남기도록 변경했습니다.
- 같은 달에 `/stop-wakeup`한 사용자는 `/register`로 다시 참여할 수 없고, 다음 달부터만 재등록되도록 변경했습니다.
- legacy backfill 경로의 동시 `/stop-wakeup` 요청이 idempotent 하도록 exclusion 기록 방식을 정리했습니다.
- `AGENTS.md`, `docs/PROJECT.md`, `docs/USER_STORIES.md`를 새 정책에 맞게 갱신했습니다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
  B1[Before: stop-wakeup keeps current month snapshot] --> B2[Current month report and self-service can still treat user as active]
  A1[After: stop-wakeup removes current month snapshot and writes exclusion] --> A2[Current month auto-recovery is blocked and register is allowed again only next month]
```

## 이번 PR 범위

- 범위 포함:
  - `/stop-wakeup` 즉시 중단 정책 반영
  - 같은 달 `/register` 재등록 차단
  - 관련 테스트와 문서 갱신
- 범위 제외:
  - 월별 집계 스키마 변경
  - 관리자 `/delete` 정책 변경
  - 휴가/출석 집계 규칙 변경

## 문서 영향

- 업데이트함:
  - `AGENTS.md`
  - `docs/PROJECT.md`
  - `docs/USER_STORIES.md`
- 이유:
  - self-service 명령 정책, 현재 월 데이터 흐름, 같은 달 재등록 제한 규칙이 바뀌었기 때문입니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- 완료조건 확인:
  - [x] `/stop-wakeup`이 현재 월 `Users` 스냅샷을 제거하고 `WakeUpMembership.status=stopped`로 바뀝니다.
  - [x] 현재 월 exclusion이 남아 같은 달 리포트/휴가/출석 경로에서 자동 복구되지 않습니다.
  - [x] 같은 달 `/stop-wakeup` 후 `/register` 재등록이 거부되고, 다음 달에는 재등록됩니다.
  - [x] legacy `Users`만 있는 참가자도 같은 정책으로 중단됩니다.
  - [x] 관련 테스트와 문서가 새 정책과 일치합니다.
- red/green 확인:
  - [x] 구현 전 `src/test/US-16-wakeup-membership.test.ts`에서 현재 월 exclusion 부재와 같은 달 `/register` 허용을 재현하는 failing test를 확인했습니다.
  - [x] 구현 후 `src/test/US-16-wakeup-membership.test.ts`, `src/test/US-01-register.test.ts`가 green 입니다.
  - [x] legacy backfill 경로의 동시 `/stop-wakeup` 요청도 최종 green 으로 확인했습니다.

## 추가된 테스트 명세

- `/stop-wakeup`이 현재 월 참가를 즉시 중단하고 현재 월 자동 복구도 막는 시나리오
- 같은 달에 `/stop-wakeup`한 사용자가 그 달에 `/register`로 다시 참여하지 못하는 시나리오
- 이전 달에 중단한 사용자가 다음 달에 `/register`로 다시 참여하는 시나리오
- legacy `Users` backfill 경로에서 동시 `/stop-wakeup` 요청이 unique 충돌 없이 idempotent 한 시나리오

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 있다면 PR 본문에 단일 `mermaid` 블록과 최상위 `Before: ...` / `After: ...` 박스를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 CI: `npm run local:ci` 통과
- 이슈 검증 명령: `npx vitest run src/test/US-16-wakeup-membership.test.ts src/test/US-01-register.test.ts`, `npm run build` 통과
