### PR TITLE
feat: testChannelId self-service 버튼 UI 샘플 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,13 @@
 - `/register`, `/stop-wakeup`, `/apply-vacation`은 `#start-here`와 기상 self-service 전용 온보딩 채널에서만 실행되도록 유지한다.
 - `/register` 성공 시 `@wake-up` 역할도 함께 부여하고, 역할 부여 실패 시 DB 등록을 남기지 않도록 유지한다.
 - self-service 명령(`/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam`)은 사용자에게는 `ephemeral`로 응답하고, 운영 확인용 결과는 `testChannelId`에도 남긴다.
+- `testChannelId` 데모 경로는 `/demo-self-service-ui`로 셀프서비스 버튼 UI 메시지를 게시하고, 버튼/모달 제출도 기존 self-service 서비스/감사 로그 경로를 재사용하도록 유지한다.
 - 기상 self-service 중단은 `/stop-wakeup` 으로 처리하고, 현재 월 참여도 즉시 중단해야 한다.
 - `/stop-wakeup` 성공 시 `@wake-up` 역할도 함께 회수하고, 역할 회수 실패 시 `WakeUpMembership`을 `stopped`로 바꾸지 않도록 유지한다.
 - `/stop-wakeup` 은 현재 월 `Users` 스냅샷을 제거하고 같은 달 exclusion 을 남겨 그 달 `/register` 재등록과 자동 복구를 막아야 한다.
 - 휴가 self-service는 총 지급량 조정이 아니라 날짜 단위 사용만 담당해야 한다.
 - 캠스터디 등록 원본은 `@cam-study` 역할과 `guildMemberUpdate` 동기화로 본다.
-- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`)은 `testChannelId`에서만 실행되도록 유지한다.
+- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`, `/demo-self-service-ui`)은 `testChannelId`에서만 실행되도록 유지한다.
 - 새 커맨드를 추가하면 `src/deploy-commands.ts`와 `src/index.ts`의 동적 로딩 대상 구조를 깨지 않는지 확인한다.
 - 역할 기반 운영 흐름을 추가할 때는 `#start-here` 같은 온보딩 채널을 기준으로 두고, 신청 응답은 가능하면 `ephemeral`로 처리한다.
 
@@ -106,7 +107,7 @@
 
 - Discord 이벤트당 파일 하나를 유지한다.
 - `ready.ts`는 부팅, 테이블 sync, 매일 04:00 운영 daily message/thread 생성 스케줄, 기상 결과표 thread 댓글 전송을 포함한 집계 스케줄 등록, 캠스터디 active session 복구와 heartbeat 등록을 담당한다.
-- `interactionCreate.ts`는 채널 검증, 쿨다운, 커맨드 실행 라우팅을 담당한다.
+- `interactionCreate.ts`는 채널 검증, 쿨다운, 커맨드 실행 라우팅과 `testChannelId` 데모 button/modal interaction 라우팅을 담당한다.
 - `messageCreate.ts`는 운영 `#wake-up` 출석 thread와 테스트 `출석-demo` thread의 첫 댓글을 감지하고, 운영 thread 첫 공식 판정은 `AttendanceLog`로 즉시 저장한다.
 - `interactionCreate.ts`는 배포 전환 중 stale 슬래시 등록이 남을 수 있는 경우, 무응답으로 끝내지 말고 migration 안내를 우선 반환한다. 현재는 stale `/apply-wakeup` 에 대해 `/register` 안내를 반환한다.
 - `guildMemberUpdate.ts`는 `@cam-study` 역할 부여/회수를 감지해서 `CamStudyUsers`를 자동 동기화하고, 활성 세션 중 역할 회수면 삭제를 종료 시점까지 미룬다.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 - `#start-here`와 기상 self-service 안내 채널이 온보딩/self-service 진입점 역할을 맡습니다.
 - 기상 챌린지는 `/register <waketime>`로 참여를 시작하고, `/stop-wakeup`으로 이후 월 자동 참여를 중단합니다.
 - `/apply-cam`은 `@cam-study` 역할과 캠스터디 참가자 상태를 즉시 활성화합니다.
-- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`)은 `testChannelId`에서 실행합니다.
+- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`, `/demo-self-service-ui`)은 `testChannelId`에서 실행합니다.
 - self-service 명령(`/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam`) 응답은 사용자에게만 보이는 `ephemeral`로 처리하고, 같은 결과를 운영 확인용으로 `testChannelId`에도 남깁니다.
+- `/demo-self-service-ui`는 `testChannelId`에 버튼/모달 기반 self-service 샘플 메시지를 게시하며, 데모 버튼도 기존 self-service 서비스 로직과 같은 감사 로그를 재사용합니다.
 
 ## 캠스터디
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -36,13 +36,13 @@
 
 ### 채널별 고정/반복 안내 메시지
 
-| 채널               | 메시지 유형      | 설명                                                                                          | 출처                           |
-| ------------------ | ---------------- | --------------------------------------------------------------------------------------------- | ------------------------------ |
-| `#start-here`      | 고정 안내        | 서버 소개, 참여 방법, 공통 self-service 명령어 고정 안내                                      | 운영 수동 관리, `USER_STORIES` |
-| `#time-start-here` | 고정 안내        | 기상 self-service 명령어와 시간 설정/휴가 사용 안내                                           | 운영 수동 관리, `USER_STORIES` |
-| `#wake-up`         | 반복 자동 메시지 | 매일 04:00 daily message와 출석 thread, thread guide, 보너스 규칙 안내                        | `src/daily-attendance.ts`      |
-| `#wake-up`         | 반복 자동 메시지 | 평일 13:00 당일 출석 thread 댓글로 출석표 전송, 주말/공휴일 13:00 보너스 차감만 반영          | `src/services/reporting.ts`    |
-| `#test`            | 관리자 운영 허브 | `/ping`, `/delete`, `/add-vacances`, `/demo-daily-message` 실행과 self-service 결과 로그 확인 | `src/commands/haruharu/*.ts`   |
+| 채널               | 메시지 유형      | 설명                                                                                                                   | 출처                           |
+| ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `#start-here`      | 고정 안내        | 서버 소개, 참여 방법, 공통 self-service 명령어 고정 안내                                                               | 운영 수동 관리, `USER_STORIES` |
+| `#time-start-here` | 고정 안내        | 기상 self-service 명령어와 시간 설정/휴가 사용 안내                                                                    | 운영 수동 관리, `USER_STORIES` |
+| `#wake-up`         | 반복 자동 메시지 | 매일 04:00 daily message와 출석 thread, thread guide, 보너스 규칙 안내                                                 | `src/daily-attendance.ts`      |
+| `#wake-up`         | 반복 자동 메시지 | 평일 13:00 당일 출석 thread 댓글로 출석표 전송, 주말/공휴일 13:00 보너스 차감만 반영                                   | `src/services/reporting.ts`    |
+| `#test`            | 관리자 운영 허브 | `/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`, `/demo-self-service-ui` 실행과 self-service 결과 로그 확인 | `src/commands/haruharu/*.ts`   |
 
 ---
 
@@ -72,6 +72,7 @@ haruharu-discord-bot/
 │   │       ├── add-vacances.ts  # 휴가 추가
 │   │       ├── delete.ts        # 챌린저 삭제
 │   │       ├── demo-daily-message.ts # 테스트 채널 daily message 데모
+│   │       ├── demo-self-service-ui.ts # 테스트 채널 self-service 버튼 UI 데모
 │   │       └── ping.ts          # 헬스체크
 │   │
 │   ├── events/
@@ -87,7 +88,9 @@ haruharu-discord-bot/
 │   │   ├── camStudy.ts          # 음성 상태 전이 해석 및 학습 시간 반영
 │   │   ├── camStudyRoleSync.ts  # 역할 기반 캠스터디 참가자 동기화
 │   │   ├── participationApplication.ts # self-service 활성화/역할 부여 처리
+│   │   ├── selfServiceActions.ts # slash command/button/modal 공통 self-service 실행 래퍼
 │   │   ├── selfServiceAudit.ts  # self-service ephemeral 응답 후 test 채널 감사 로그 전송
+│   │   ├── selfServiceOnboardingDemo.ts # test 채널용 self-service 버튼/모달 데모
 │   │   └── reporting.ts         # 일일/주간 리포트 생성 및 스케줄링
 │   │
 │   └── repository/
@@ -170,10 +173,11 @@ haruharu-discord-bot/
 
 #### 유틸리티 커맨드
 
-| 내부 key              | 한국어 표시명(ko)      | 권한   | 설명                                                                   |
-| --------------------- | ---------------------- | ------ | ---------------------------------------------------------------------- |
-| `/ping`               | `/admin-상태확인`      | 관리자 | 봇 상태 확인                                                           |
-| `/demo-daily-message` | `/admin-demo-출석생성` | 관리자 | 테스트 채널에 랜덤 질문이 포함된 daily message + 출석 demo thread 생성 |
+| 내부 key                | 한국어 표시명(ko)          | 권한   | 설명                                                                   |
+| ----------------------- | -------------------------- | ------ | ---------------------------------------------------------------------- |
+| `/ping`                 | `/admin-상태확인`          | 관리자 | 봇 상태 확인                                                           |
+| `/demo-daily-message`   | `/admin-demo-출석생성`     | 관리자 | 테스트 채널에 랜덤 질문이 포함된 daily message + 출석 demo thread 생성 |
+| `/demo-self-service-ui` | `/admin-demo-셀프서비스ui` | 관리자 | 테스트 채널에 self-service 버튼/모달 데모 메시지 생성                  |
 
 ---
 
@@ -340,7 +344,8 @@ flowchart TD
 - stale `/apply-wakeup` interaction 이 들어오면 커맨드 미존재 오류로 끝내지 않고 `/register` migration 안내를 ephemeral 응답으로 반환한다.
 - `/apply-cam`은 `#start-here` 전용 채널에서만 실행된다.
 - `/apply-cam`은 사용자에게 `ephemeral`로 응답하고, 성공/실패 모두 `testChannelId`에도 남긴다.
-- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`)은 `testChannelId` 전용으로 실행된다.
+- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`, `/demo-self-service-ui`)은 `testChannelId` 전용으로 실행된다.
+- `interactionCreate.ts`는 chat input 외에도 `demo-self-service-ui`가 게시한 button / modal submit interaction 을 라우팅한다.
 
 #### camStudyHandler.ts
 
@@ -434,15 +439,23 @@ flowchart TD
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 역할   | self-service 참여 활성화와 역할 부여                                                                                                                                      |
 | 담당   | `ParticipationApplication` 조회/갱신, `@cam-study` 역할 매핑, `/apply-cam` 즉시 `approved` 반영, 캠스터디 자동 활성화 시 `CamStudyUsers` upsert, 실패 시 role/db rollback |
-| 호출처 | `src/commands/haruharu/apply-cam.ts`                                                                                                                                      |
+| 호출처 | `src/commands/haruharu/apply-cam.ts`, `src/services/selfServiceActions.ts`                                                                                                |
+
+#### selfServiceActions.ts
+
+| 항목   | 내용                                                                                                                                                                                                      |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 역할   | slash command 와 test 채널 button/modal 데모가 공통 self-service 서비스와 감사 로그 경로를 재사용하도록 정리                                                                                              |
+| 담당   | `/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam`의 공통 실행 래퍼, display name 해석, 성공/실패 `ephemeral` 응답과 `testChannelId` 감사 로그 연결                                             |
+| 호출처 | `src/commands/haruharu/register.ts`, `src/commands/haruharu/stop-wakeup.ts`, `src/commands/haruharu/apply-vacation.ts`, `src/commands/haruharu/apply-cam.ts`, `src/services/selfServiceOnboardingDemo.ts` |
 
 #### selfServiceAudit.ts
 
-| 항목   | 내용                                                                                                                                                         |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 역할   | self-service 명령 응답을 사용자 `ephemeral` 응답과 `testChannelId` 운영 로그로 분리                                                                          |
-| 담당   | `/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam`의 결과 문자열 추출, `testChannelId` 전송, 전송 실패 시 서버 logger fallback 처리                |
-| 호출처 | `src/commands/haruharu/register.ts`, `src/commands/haruharu/stop-wakeup.ts`, `src/commands/haruharu/apply-vacation.ts`, `src/commands/haruharu/apply-cam.ts` |
+| 항목   | 내용                                                                                                                          |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| 역할   | self-service 응답을 사용자 `ephemeral` 응답과 `testChannelId` 운영 로그로 분리                                                |
+| 담당   | slash command 와 test 채널 button/modal 경로의 결과 문자열 추출, `testChannelId` 전송, 전송 실패 시 서버 logger fallback 처리 |
+| 호출처 | `src/services/selfServiceActions.ts`                                                                                          |
 
 #### reporting.ts
 
@@ -756,10 +769,12 @@ flowchart TD
 - `/apply-vacation`은 Discord 한국어 locale에서 `/휴가신청`으로 표시되며 현재 월 날짜 단위(`yyyymmdd`)로 동작한다.
 - 관리자 전용 커맨드는 Discord 한국어 locale에서 `admin-...` 접두어로 표시된다.
 - 데모 전용 커맨드는 Discord 한국어 locale에서 `admin-demo-...` 접두어로 표시된다.
-- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`)은 `testChannelId`에서만 실행된다.
+- 관리자 명령(`/ping`, `/delete`, `/add-vacances`, `/demo-daily-message`, `/demo-self-service-ui`)은 `testChannelId`에서만 실행된다.
 - stale `/apply-wakeup` interaction 은 잘못된 채널 안내 대신 `/register` migration 응답으로 종료한다.
 - `/apply-cam`은 `#start-here`에서만 실행되고, 실행 즉시 역할 부여와 `approved` 상태 반영을 시도하며 결과는 `ephemeral`로 응답하고 같은 내용을 `testChannelId`에도 남긴다.
 - `/apply-cam` 성공 시 `@cam-study` 역할과 `CamStudyUsers`가 함께 맞춰지고, 이후 역할 변경은 `guildMemberUpdate`가 계속 동기화한다.
+- `/demo-self-service-ui`는 `testChannelId`에 `기상 등록/수정`, `휴가 신청`, `기상 중단`, `캠스터디 참여` 버튼을 가진 데모 메시지를 게시한다.
+- 데모 버튼/모달 경로도 실제 `/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam`과 같은 서비스 로직과 `testChannelId` 감사 로그 경로를 재사용한다.
 - 휴가가 등록된 날짜는 일일 출석 리포트에서 `휴가`로 표시되고, 결석 카운트는 증가하지 않는다.
 - 주말/공휴일에도 `#wake-up` daily message/thread는 생성된다.
 - 주말/공휴일 13:00 집계는 결과 메시지를 보내지 않고, `AttendanceLog.status='attended'` 인 사용자만 결석 1회 우선 차감 후 없으면 지각 1회를 차감한다.

--- a/src/commands/haruharu/apply-cam.ts
+++ b/src/commands/haruharu/apply-cam.ts
@@ -1,7 +1,6 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import { startHereChannelId } from '../../commandChannelConfig.js';
-import { logger } from '../../logger.js';
-import { getReplyContent, sendSelfServiceAuditLog } from '../../services/selfServiceAudit.js';
+import { executeApplyCamSelfService } from '../../services/selfServiceActions.js';
 
 export const command = {
   cooldown: 5,
@@ -12,27 +11,9 @@ export const command = {
     .setNameLocalizations({ ko: '캠스터디신청' })
     .setDescriptionLocalizations({ ko: '캠스터디 참여를 신청합니다' }),
   async execute(interaction: ChatInputCommandInteraction) {
-    try {
-      const { submitParticipationApplication } = await import('../../services/participationApplication.js');
-      const reply = await submitParticipationApplication(interaction, 'cam-study');
-      await interaction.reply(reply);
-      await sendSelfServiceAuditLog({
-        commandName: command.data.name,
-        interaction,
-        reply,
-      });
-    } catch (error) {
-      logger.error('apply-cam 실행 실패', { error });
-      const reply = {
-        content: '캠스터디 참여 처리에 실패했습니다',
-        ephemeral: true,
-      };
-      await interaction.reply(reply);
-      await sendSelfServiceAuditLog({
-        commandName: command.data.name,
-        interaction,
-        reply: getReplyContent(reply),
-      });
-    }
+    await executeApplyCamSelfService({
+      interaction,
+      commandName: command.data.name,
+    });
   },
 };

--- a/src/commands/haruharu/apply-vacation.ts
+++ b/src/commands/haruharu/apply-vacation.ts
@@ -1,7 +1,6 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import { startHereChannelId, timeStartHereChannelId } from '../../commandChannelConfig.js';
-import { logger } from '../../logger.js';
-import { replyWithEphemeralAudit } from '../../services/selfServiceAudit.js';
+import { executeApplyVacationSelfService } from '../../services/selfServiceActions.js';
 
 export const command = {
   cooldown: 5,
@@ -20,25 +19,10 @@ export const command = {
         .setRequired(true),
     ),
   async execute(interaction: ChatInputCommandInteraction) {
-    try {
-      const { executeApplyVacation } = await import('../../services/challengeSelfService.js');
-      const result = await executeApplyVacation({
-        userId: interaction.user.id,
-        yearmonthday: interaction.options.getString('date') ?? '',
-      });
-
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: result.reply,
-      });
-    } catch (error) {
-      logger.error('apply-vacation 실행 실패', { error });
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: '휴가 신청 처리에 실패했습니다',
-      });
-    }
+    await executeApplyVacationSelfService({
+      interaction,
+      yearmonthday: interaction.options.getString('date') ?? '',
+      commandName: command.data.name,
+    });
   },
 };

--- a/src/commands/haruharu/demo-self-service-ui.ts
+++ b/src/commands/haruharu/demo-self-service-ui.ts
@@ -1,0 +1,33 @@
+import { ChannelType, ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { testChannelId } from '../../commandChannelConfig.js';
+import { logger } from '../../logger.js';
+import { buildSelfServiceDemoMessage } from '../../services/selfServiceOnboardingDemo.js';
+import { PERMISSION_NUM_ADMIN } from '../../utils.js';
+
+export const command = {
+  cooldown: 5,
+  allowedChannelIds: [testChannelId],
+  data: new SlashCommandBuilder()
+    .setName('demo-self-service-ui')
+    .setDescription('post a self-service onboarding button demo message in the test channel')
+    .setNameLocalizations({ ko: 'admin-demo-셀프서비스ui' })
+    .setDescriptionLocalizations({ ko: '관리자가 테스트 채널에 셀프서비스 버튼 UI 데모 메시지를 게시합니다' })
+    .setDefaultMemberPermissions(PERMISSION_NUM_ADMIN),
+  async execute(interaction: ChatInputCommandInteraction) {
+    const channel = await interaction.client.channels.fetch(testChannelId);
+
+    if (!channel || channel.type !== ChannelType.GuildText) {
+      logger.error('demo-self-service-ui invalid test channel', { testChannelId });
+      return await interaction.reply({
+        content: '테스트 채널을 찾을 수 없습니다',
+        ephemeral: true,
+      });
+    }
+
+    await channel.send(buildSelfServiceDemoMessage());
+    await interaction.reply({
+      content: '셀프서비스 데모 메시지를 게시했습니다',
+      ephemeral: true,
+    });
+  },
+};

--- a/src/commands/haruharu/register.ts
+++ b/src/commands/haruharu/register.ts
@@ -1,24 +1,6 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import { startHereChannelId, timeStartHereChannelId } from '../../commandChannelConfig.js';
-import { logger } from '../../logger.js';
-import { replyWithEphemeralAudit } from '../../services/selfServiceAudit.js';
-
-const resolveRegisterUsername = (interaction: ChatInputCommandInteraction) => {
-  const member = interaction.member as {
-    displayName?: string | null;
-    nickname?: string | null;
-    nick?: string | null;
-  } | null;
-
-  return (
-    member?.displayName ??
-    member?.nickname ??
-    member?.nick ??
-    interaction.user.globalName ??
-    interaction.user.username ??
-    'unknown'
-  );
-};
+import { executeRegisterSelfService } from '../../services/selfServiceActions.js';
 
 export const command = {
   cooldown: 5,
@@ -37,32 +19,10 @@ export const command = {
         .setRequired(true),
     ),
   async execute(interaction: ChatInputCommandInteraction) {
-    const waketime = interaction.options.getString('waketime')!;
-    const userId = interaction.user.id;
-    const username = resolveRegisterUsername(interaction);
-    logger.info(`register 명령행에 입력한 값: userid: ${userId}, waketime: ${waketime}`);
-
-    const { executeRegisterWithRoleSync } = await import('../../services/challengeSelfService.js');
-
-    try {
-      const result = await executeRegisterWithRoleSync({
-        userId,
-        username,
-        waketime,
-        guild: interaction.guild,
-      });
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: result.reply,
-      });
-    } catch (e) {
-      logger.error(`register 등록 실패`, { e });
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: 'register 등록 실패',
-      });
-    }
+    await executeRegisterSelfService({
+      interaction,
+      waketime: interaction.options.getString('waketime') ?? '',
+      commandName: command.data.name,
+    });
   },
 };

--- a/src/commands/haruharu/stop-wakeup.ts
+++ b/src/commands/haruharu/stop-wakeup.ts
@@ -1,7 +1,6 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 import { startHereChannelId, timeStartHereChannelId } from '../../commandChannelConfig.js';
-import { logger } from '../../logger.js';
-import { replyWithEphemeralAudit } from '../../services/selfServiceAudit.js';
+import { executeStopWakeupSelfService } from '../../services/selfServiceActions.js';
 
 export const command = {
   cooldown: 5,
@@ -12,25 +11,9 @@ export const command = {
     .setNameLocalizations({ ko: '기상중단' })
     .setDescriptionLocalizations({ ko: '기상스터디 참여를 중단합니다' }),
   async execute(interaction: ChatInputCommandInteraction) {
-    const { executeStopWakeUpWithRoleSync } = await import('../../services/challengeSelfService.js');
-
-    try {
-      const result = await executeStopWakeUpWithRoleSync({
-        userId: interaction.user.id,
-        guild: interaction.guild,
-      });
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: result.reply,
-      });
-    } catch (error) {
-      logger.error('stop-wakeup 실행 실패', { error });
-      await replyWithEphemeralAudit({
-        commandName: command.data.name,
-        interaction,
-        content: '기상스터디 중단 처리에 실패했습니다',
-      });
-    }
+    await executeStopWakeupSelfService({
+      interaction,
+      commandName: command.data.name,
+    });
   },
 };

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,4 @@
-import { Events, Collection, ChatInputCommandInteraction } from 'discord.js';
+import { Events, Collection, type Interaction } from 'discord.js';
 import { commandChannelIds } from '../config.js';
 import type { MyClient } from '../runtime.js';
 
@@ -12,7 +12,29 @@ const buildInvalidChannelMessage = (commandName: string) => {
 
 export const event = {
   name: Events.InteractionCreate,
-  async execute(interaction: ChatInputCommandInteraction) {
+  async execute(interaction: Interaction) {
+    if ('isButton' in interaction && typeof interaction.isButton === 'function' && interaction.isButton()) {
+      const { handleSelfServiceDemoButtonInteraction, isSelfServiceDemoButtonCustomId } =
+        await import('../services/selfServiceOnboardingDemo.js');
+      if (isSelfServiceDemoButtonCustomId(interaction.customId)) {
+        await handleSelfServiceDemoButtonInteraction(interaction);
+      }
+      return;
+    }
+
+    if (
+      'isModalSubmit' in interaction &&
+      typeof interaction.isModalSubmit === 'function' &&
+      interaction.isModalSubmit()
+    ) {
+      const { handleSelfServiceDemoModalSubmitInteraction, isSelfServiceDemoModalCustomId } =
+        await import('../services/selfServiceOnboardingDemo.js');
+      if (isSelfServiceDemoModalCustomId(interaction.customId)) {
+        await handleSelfServiceDemoModalSubmitInteraction(interaction);
+      }
+      return;
+    }
+
     if (!interaction.isChatInputCommand()) return;
 
     const command = (interaction.client as MyClient).commands.get(interaction.commandName);

--- a/src/services/participationApplication.ts
+++ b/src/services/participationApplication.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import { Guild, GuildMember } from 'discord.js';
 import { camStudyRoleId } from '../config.js';
 import { logger } from '../logger.js';
 import { ParticipationApplication } from '../repository/ParticipationApplication.js';
@@ -88,7 +88,14 @@ const persistApprovedApplication = async (
 };
 
 const submitParticipationApplication = async (
-  interaction: ChatInputCommandInteraction,
+  interaction: {
+    guild: Guild | null;
+    user: {
+      id: string;
+      globalName?: string | null;
+      username: string;
+    };
+  },
   program: ParticipationProgram,
 ) => {
   const userid = interaction.user.id;

--- a/src/services/selfServiceActions.ts
+++ b/src/services/selfServiceActions.ts
@@ -1,0 +1,171 @@
+import type { Guild, InteractionReplyOptions } from 'discord.js';
+import { logger } from '../logger.js';
+import { getReplyContent, replyWithEphemeralAudit, sendSelfServiceAuditLog } from './selfServiceAudit.js';
+
+type SelfServiceInteraction = {
+  channelId: string | null;
+  client: {
+    channels: {
+      fetch: (channelId: string) => Promise<unknown>;
+    };
+  };
+  guild: Guild | null;
+  member?: {
+    displayName?: string | null;
+    nickname?: string | null;
+    nick?: string | null;
+  } | null;
+  reply: (options: InteractionReplyOptions) => Promise<unknown>;
+  user: {
+    id: string;
+    globalName?: string | null;
+    username: string;
+  };
+};
+
+const resolveInteractionUsername = (interaction: SelfServiceInteraction) => {
+  return (
+    interaction.member?.displayName ??
+    interaction.member?.nickname ??
+    interaction.member?.nick ??
+    interaction.user.globalName ??
+    interaction.user.username ??
+    'unknown'
+  );
+};
+
+const executeRegisterSelfService = async ({
+  interaction,
+  waketime,
+  commandName = 'register',
+}: {
+  interaction: SelfServiceInteraction;
+  waketime: string;
+  commandName?: string;
+}) => {
+  const userId = interaction.user.id;
+  const username = resolveInteractionUsername(interaction);
+  logger.info(`register 명령행에 입력한 값: userid: ${userId}, waketime: ${waketime}`);
+
+  const { executeRegisterWithRoleSync } = await import('./challengeSelfService.js');
+
+  try {
+    const result = await executeRegisterWithRoleSync({
+      userId,
+      username,
+      waketime,
+      guild: interaction.guild,
+    });
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: result.reply,
+    });
+  } catch (error) {
+    logger.error('register 등록 실패', { error });
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: 'register 등록 실패',
+    });
+  }
+};
+
+const executeApplyVacationSelfService = async ({
+  interaction,
+  yearmonthday,
+  commandName = 'apply-vacation',
+}: {
+  interaction: SelfServiceInteraction;
+  yearmonthday: string;
+  commandName?: string;
+}) => {
+  try {
+    const { executeApplyVacation } = await import('./challengeSelfService.js');
+    const result = await executeApplyVacation({
+      userId: interaction.user.id,
+      yearmonthday,
+    });
+
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: result.reply,
+    });
+  } catch (error) {
+    logger.error('apply-vacation 실행 실패', { error });
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: '휴가 신청 처리에 실패했습니다',
+    });
+  }
+};
+
+const executeStopWakeupSelfService = async ({
+  interaction,
+  commandName = 'stop-wakeup',
+}: {
+  interaction: SelfServiceInteraction;
+  commandName?: string;
+}) => {
+  const { executeStopWakeUpWithRoleSync } = await import('./challengeSelfService.js');
+
+  try {
+    const result = await executeStopWakeUpWithRoleSync({
+      userId: interaction.user.id,
+      guild: interaction.guild,
+    });
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: result.reply,
+    });
+  } catch (error) {
+    logger.error('stop-wakeup 실행 실패', { error });
+    await replyWithEphemeralAudit({
+      commandName,
+      interaction,
+      content: '기상스터디 중단 처리에 실패했습니다',
+    });
+  }
+};
+
+const executeApplyCamSelfService = async ({
+  interaction,
+  commandName = 'apply-cam',
+}: {
+  interaction: SelfServiceInteraction;
+  commandName?: string;
+}) => {
+  try {
+    const { submitParticipationApplication } = await import('./participationApplication.js');
+    const reply = await submitParticipationApplication(interaction, 'cam-study');
+    await interaction.reply(reply);
+    await sendSelfServiceAuditLog({
+      commandName,
+      interaction,
+      reply,
+    });
+  } catch (error) {
+    logger.error('apply-cam 실행 실패', { error });
+    const reply = {
+      content: '캠스터디 참여 처리에 실패했습니다',
+      ephemeral: true,
+    } satisfies InteractionReplyOptions;
+    await interaction.reply(reply);
+    await sendSelfServiceAuditLog({
+      commandName,
+      interaction,
+      reply: getReplyContent(reply),
+    });
+  }
+};
+
+export {
+  executeApplyCamSelfService,
+  executeApplyVacationSelfService,
+  executeRegisterSelfService,
+  executeStopWakeupSelfService,
+  resolveInteractionUsername,
+};

--- a/src/services/selfServiceAudit.ts
+++ b/src/services/selfServiceAudit.ts
@@ -1,8 +1,25 @@
-import type { ChatInputCommandInteraction, InteractionReplyOptions } from 'discord.js';
+import type { InteractionReplyOptions } from 'discord.js';
 import { testChannelId } from '../commandChannelConfig.js';
 import { logger } from '../logger.js';
 
 type ReplyPayload = string | InteractionReplyOptions;
+type SendableChannel = {
+  send: (options: { content: string; allowedMentions: { parse: [] } }) => Promise<unknown>;
+};
+type SelfServiceAuditInteraction = {
+  channelId: string | null;
+  client: {
+    channels: {
+      fetch: (channelId: string) => Promise<unknown>;
+    };
+  };
+  reply: (options: InteractionReplyOptions) => Promise<unknown>;
+  user: {
+    id: string;
+    globalName?: string | null;
+    username: string;
+  };
+};
 
 const getReplyContent = (reply: ReplyPayload) => {
   if (typeof reply === 'string') {
@@ -22,7 +39,7 @@ const buildAuditMessage = ({
   reply,
 }: {
   commandName: string;
-  interaction: ChatInputCommandInteraction;
+  interaction: SelfServiceAuditInteraction;
   reply: ReplyPayload;
 }) => {
   const username = interaction.user.globalName ?? interaction.user.username ?? 'unknown';
@@ -37,18 +54,26 @@ const buildAuditMessage = ({
   ].join('\n');
 };
 
+const isSendableChannel = (channel: unknown): channel is SendableChannel => {
+  if (typeof channel !== 'object' || channel === null) {
+    return false;
+  }
+
+  return 'send' in channel && typeof channel.send === 'function';
+};
+
 const sendSelfServiceAuditLog = async ({
   commandName,
   interaction,
   reply,
 }: {
   commandName: string;
-  interaction: ChatInputCommandInteraction;
+  interaction: SelfServiceAuditInteraction;
   reply: ReplyPayload;
 }) => {
   try {
     const channel = await interaction.client.channels.fetch(testChannelId);
-    if (!channel || !('send' in channel)) {
+    if (!isSendableChannel(channel)) {
       logger.error('self-service audit target is not sendable', {
         commandName,
         testChannelId,
@@ -78,7 +103,7 @@ const replyWithEphemeralAudit = async ({
   content,
 }: {
   commandName: string;
-  interaction: ChatInputCommandInteraction;
+  interaction: SelfServiceAuditInteraction;
   content: string;
 }) => {
   const reply = {

--- a/src/services/selfServiceOnboardingDemo.ts
+++ b/src/services/selfServiceOnboardingDemo.ts
@@ -1,0 +1,201 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  type ButtonInteraction,
+  type InteractionReplyOptions,
+  type ModalSubmitInteraction,
+} from 'discord.js';
+import { testChannelId } from '../commandChannelConfig.js';
+import {
+  executeApplyCamSelfService,
+  executeApplyVacationSelfService,
+  executeRegisterSelfService,
+  executeStopWakeupSelfService,
+} from './selfServiceActions.js';
+
+const SELF_SERVICE_DEMO_PREFIX = 'self-service-demo:';
+const REGISTER_OPEN_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}register:open`;
+const REGISTER_SUBMIT_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}register:submit`;
+const APPLY_VACATION_OPEN_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}apply-vacation:open`;
+const APPLY_VACATION_SUBMIT_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}apply-vacation:submit`;
+const STOP_WAKEUP_OPEN_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}stop-wakeup:open`;
+const STOP_WAKEUP_CONFIRM_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}stop-wakeup:confirm`;
+const STOP_WAKEUP_CANCEL_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}stop-wakeup:cancel`;
+const APPLY_CAM_CUSTOM_ID = `${SELF_SERVICE_DEMO_PREFIX}apply-cam:submit`;
+const REGISTER_WAKETIME_INPUT_ID = 'waketime';
+const APPLY_VACATION_DATE_INPUT_ID = 'date';
+
+const buildRegisterModal = () =>
+  new ModalBuilder()
+    .setCustomId(REGISTER_SUBMIT_CUSTOM_ID)
+    .setTitle('기상 등록/수정')
+    .addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId(REGISTER_WAKETIME_INPUT_ID)
+          .setLabel('기상시간 (HHmm)')
+          .setPlaceholder('0700')
+          .setRequired(true)
+          .setStyle(TextInputStyle.Short),
+      ),
+    );
+
+const buildApplyVacationModal = () =>
+  new ModalBuilder()
+    .setCustomId(APPLY_VACATION_SUBMIT_CUSTOM_ID)
+    .setTitle('휴가 신청')
+    .addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId(APPLY_VACATION_DATE_INPUT_ID)
+          .setLabel('휴가 날짜 (yyyymmdd)')
+          .setPlaceholder('20260330')
+          .setRequired(true)
+          .setStyle(TextInputStyle.Short),
+      ),
+    );
+
+const buildStopWakeupConfirmReply = () =>
+  ({
+    content: '기상스터디 참여를 중단할까요? 확인을 누르면 기존 `/stop-wakeup` 처리 로직을 그대로 실행합니다.',
+    ephemeral: true,
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(STOP_WAKEUP_CONFIRM_CUSTOM_ID)
+          .setLabel('중단 확인')
+          .setStyle(ButtonStyle.Danger),
+        new ButtonBuilder().setCustomId(STOP_WAKEUP_CANCEL_CUSTOM_ID).setLabel('취소').setStyle(ButtonStyle.Secondary),
+      ),
+    ],
+  }) satisfies InteractionReplyOptions;
+
+const buildInvalidDemoChannelReply = () =>
+  ({
+    content: '이 셀프서비스 데모는 `testChannelId` 채널에서만 사용할 수 있어요.',
+    ephemeral: true,
+  }) satisfies InteractionReplyOptions;
+
+const ensureDemoChannel = async (interaction: {
+  channelId: string | null;
+  reply: (options: InteractionReplyOptions) => Promise<unknown>;
+}) => {
+  if (interaction.channelId === testChannelId) {
+    return true;
+  }
+
+  await interaction.reply(buildInvalidDemoChannelReply());
+  return false;
+};
+
+const buildSelfServiceDemoMessage = () => ({
+  content: [
+    '[self-service-demo]',
+    '테스트 채널에서 버튼/모달 self-service 흐름을 샘플로 검증하는 메시지입니다.',
+    '- 기상 등록/수정: modal 입력 후 기존 `/register` 서비스 로직 재사용',
+    '- 휴가 신청: modal 입력 후 기존 `/apply-vacation` 서비스 로직 재사용',
+    '- 기상 중단: 확인 단계 후 기존 `/stop-wakeup` 서비스 로직 재사용',
+    '- 캠스터디 참여: 기존 `/apply-cam` 서비스 로직 재사용',
+  ].join('\n'),
+  components: [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId(REGISTER_OPEN_CUSTOM_ID).setLabel('기상 등록/수정').setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId(APPLY_VACATION_OPEN_CUSTOM_ID)
+        .setLabel('휴가 신청')
+        .setStyle(ButtonStyle.Secondary),
+    ),
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId(STOP_WAKEUP_OPEN_CUSTOM_ID).setLabel('기상 중단').setStyle(ButtonStyle.Danger),
+      new ButtonBuilder().setCustomId(APPLY_CAM_CUSTOM_ID).setLabel('캠스터디 참여').setStyle(ButtonStyle.Success),
+    ),
+  ],
+});
+
+const isSelfServiceDemoButtonCustomId = (customId: string) =>
+  [
+    REGISTER_OPEN_CUSTOM_ID,
+    APPLY_VACATION_OPEN_CUSTOM_ID,
+    STOP_WAKEUP_OPEN_CUSTOM_ID,
+    STOP_WAKEUP_CONFIRM_CUSTOM_ID,
+    STOP_WAKEUP_CANCEL_CUSTOM_ID,
+    APPLY_CAM_CUSTOM_ID,
+  ].includes(customId);
+
+const isSelfServiceDemoModalCustomId = (customId: string) =>
+  [REGISTER_SUBMIT_CUSTOM_ID, APPLY_VACATION_SUBMIT_CUSTOM_ID].includes(customId);
+
+const handleSelfServiceDemoButtonInteraction = async (interaction: ButtonInteraction) => {
+  if (!(await ensureDemoChannel(interaction))) {
+    return;
+  }
+
+  switch (interaction.customId) {
+    case REGISTER_OPEN_CUSTOM_ID:
+      await interaction.showModal(buildRegisterModal());
+      return;
+    case APPLY_VACATION_OPEN_CUSTOM_ID:
+      await interaction.showModal(buildApplyVacationModal());
+      return;
+    case STOP_WAKEUP_OPEN_CUSTOM_ID:
+      await interaction.reply(buildStopWakeupConfirmReply());
+      return;
+    case STOP_WAKEUP_CONFIRM_CUSTOM_ID:
+      await executeStopWakeupSelfService({
+        interaction,
+        commandName: 'stop-wakeup',
+      });
+      return;
+    case STOP_WAKEUP_CANCEL_CUSTOM_ID:
+      await interaction.reply({
+        content: '기상스터디 중단을 취소했습니다.',
+        ephemeral: true,
+      });
+      return;
+    case APPLY_CAM_CUSTOM_ID:
+      await executeApplyCamSelfService({
+        interaction,
+        commandName: 'apply-cam',
+      });
+      return;
+    default:
+      return;
+  }
+};
+
+const handleSelfServiceDemoModalSubmitInteraction = async (interaction: ModalSubmitInteraction) => {
+  if (!(await ensureDemoChannel(interaction))) {
+    return;
+  }
+
+  switch (interaction.customId) {
+    case REGISTER_SUBMIT_CUSTOM_ID:
+      await executeRegisterSelfService({
+        interaction,
+        waketime: interaction.fields.getTextInputValue(REGISTER_WAKETIME_INPUT_ID),
+        commandName: 'register',
+      });
+      return;
+    case APPLY_VACATION_SUBMIT_CUSTOM_ID:
+      await executeApplyVacationSelfService({
+        interaction,
+        yearmonthday: interaction.fields.getTextInputValue(APPLY_VACATION_DATE_INPUT_ID),
+        commandName: 'apply-vacation',
+      });
+      return;
+    default:
+      return;
+  }
+};
+
+export {
+  buildSelfServiceDemoMessage,
+  handleSelfServiceDemoButtonInteraction,
+  handleSelfServiceDemoModalSubmitInteraction,
+  isSelfServiceDemoButtonCustomId,
+  isSelfServiceDemoModalCustomId,
+};

--- a/src/test/US-18-self-service-onboarding-demo.test.ts
+++ b/src/test/US-18-self-service-onboarding-demo.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChannelType, PermissionFlagsBits } from 'discord.js';
+
+vi.mock('node:module', async importOriginal => {
+  const original = await importOriginal<typeof import('node:module')>();
+  return {
+    ...original,
+    createRequire: () => (path: string) => {
+      if (path.includes('config.json')) {
+        return {
+          token: 'test-token',
+          clientId: 'test-client-id',
+          guildId: 'test-guild-id',
+          checkChannelId: 'valid-check-channel-id',
+          testChannelId: 'valid-test-channel-id',
+          logChannelId: 'valid-log-channel-id',
+          resultChannelId: 'valid-result-channel-id',
+          voiceChannelId: 'valid-voice-channel-id',
+          startHereChannelId: 'valid-start-here-channel-id',
+          timeStartHereChannelId: 'valid-time-start-here-channel-id',
+          wakeUpRoleId: 'valid-wake-up-role-id',
+          camStudyRoleId: 'valid-cam-study-role-id',
+        };
+      }
+
+      return original.createRequire(import.meta.url)(path);
+    },
+  };
+});
+
+const createDemoInteraction = (fetch: ReturnType<typeof vi.fn>) => {
+  const replies: Array<string | { content: string; ephemeral?: boolean }> = [];
+
+  return {
+    client: {
+      channels: {
+        fetch,
+      },
+    },
+    reply: async (content: string | { content: string; ephemeral?: boolean }) => {
+      replies.push(content);
+      return content;
+    },
+    getReplies: () => replies,
+    getLastReply: () => {
+      const last = replies[replies.length - 1];
+      return typeof last === 'string' ? last : last?.content;
+    },
+  };
+};
+
+describe('US-18: self-service 온보딩 버튼 데모', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('demo-self-service-ui 커맨드는 테스트 채널에 버튼 UI 메시지를 게시한다', async () => {
+    const send = vi.fn().mockResolvedValue({ id: 'demo-self-service-message' });
+    const fetch = vi.fn().mockResolvedValue({
+      type: ChannelType.GuildText,
+      send,
+    });
+    const interaction = createDemoInteraction(fetch);
+
+    const { command } = await import('../commands/haruharu/demo-self-service-ui.js');
+    await command.execute(interaction as never);
+
+    expect(fetch).toHaveBeenCalledWith('valid-test-channel-id');
+    expect(send).toHaveBeenCalledOnce();
+    const payload = send.mock.calls[0]?.[0];
+    expect(payload.content).toContain('[self-service-demo]');
+    const componentLabels = payload.components.flatMap(
+      (row: { toJSON: () => { components: Array<{ label: string }> } }) =>
+        row.toJSON().components.map(component => component.label),
+    );
+    expect(componentLabels).toEqual(
+      expect.arrayContaining(['기상 등록/수정', '휴가 신청', '기상 중단', '캠스터디 참여']),
+    );
+    expect(interaction.getLastReply()).toContain('셀프서비스 데모 메시지를 게시했습니다');
+  });
+
+  it('demo-self-service-ui 커맨드는 관리자 권한 비트를 사용한다', async () => {
+    const { command } = await import('../commands/haruharu/demo-self-service-ui.js');
+
+    expect(command.data.toJSON().default_member_permissions).toBe(PermissionFlagsBits.Administrator.toString());
+  });
+
+  it('기상 중단 버튼의 첫 클릭은 중단을 실행하지 않고 확인 단계를 연다', async () => {
+    const executeStopWakeupSelfService = vi.fn();
+    vi.doMock('../services/selfServiceActions.js', () => ({
+      executeRegisterSelfService: vi.fn(),
+      executeApplyVacationSelfService: vi.fn(),
+      executeStopWakeupSelfService,
+      executeApplyCamSelfService: vi.fn(),
+    }));
+
+    const { handleSelfServiceDemoButtonInteraction } = await import('../services/selfServiceOnboardingDemo.js');
+    const reply = vi.fn();
+    const interaction = {
+      customId: 'self-service-demo:stop-wakeup:open',
+      channelId: 'valid-test-channel-id',
+      reply,
+      showModal: vi.fn(),
+    };
+
+    await handleSelfServiceDemoButtonInteraction(interaction as never);
+
+    expect(executeStopWakeupSelfService).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('기상스터디 참여를 중단할까요'),
+        ephemeral: true,
+      }),
+    );
+  });
+
+  it('기상 중단 확인 버튼은 기존 self-service 중단 경로를 재사용한다', async () => {
+    const executeStopWakeupSelfService = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('../services/selfServiceActions.js', () => ({
+      executeRegisterSelfService: vi.fn(),
+      executeApplyVacationSelfService: vi.fn(),
+      executeStopWakeupSelfService,
+      executeApplyCamSelfService: vi.fn(),
+    }));
+
+    const { handleSelfServiceDemoButtonInteraction } = await import('../services/selfServiceOnboardingDemo.js');
+    const interaction = {
+      customId: 'self-service-demo:stop-wakeup:confirm',
+      channelId: 'valid-test-channel-id',
+      reply: vi.fn(),
+      showModal: vi.fn(),
+    };
+
+    await handleSelfServiceDemoButtonInteraction(interaction as never);
+
+    expect(executeStopWakeupSelfService).toHaveBeenCalledWith({
+      interaction,
+      commandName: 'stop-wakeup',
+    });
+  });
+
+  it('기상 등록 modal submit은 입력값을 기존 register 처리 경로로 전달한다', async () => {
+    const executeRegisterSelfService = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('../services/selfServiceActions.js', () => ({
+      executeRegisterSelfService,
+      executeApplyVacationSelfService: vi.fn(),
+      executeStopWakeupSelfService: vi.fn(),
+      executeApplyCamSelfService: vi.fn(),
+    }));
+
+    const { handleSelfServiceDemoModalSubmitInteraction } = await import('../services/selfServiceOnboardingDemo.js');
+    const interaction = {
+      customId: 'self-service-demo:register:submit',
+      channelId: 'valid-test-channel-id',
+      fields: {
+        getTextInputValue: vi.fn().mockReturnValue('0730'),
+      },
+      reply: vi.fn(),
+    };
+
+    await handleSelfServiceDemoModalSubmitInteraction(interaction as never);
+
+    expect(executeRegisterSelfService).toHaveBeenCalledWith({
+      interaction,
+      waketime: '0730',
+      commandName: 'register',
+    });
+  });
+});

--- a/src/test/admin-command-routing.test.ts
+++ b/src/test/admin-command-routing.test.ts
@@ -33,6 +33,7 @@ const adminCommandSpecs = [
   '../commands/haruharu/add-vacances.js',
   '../commands/haruharu/delete.js',
   '../commands/haruharu/demo-daily-message.js',
+  '../commands/haruharu/demo-self-service-ui.js',
   '../commands/haruharu/ping.js',
 ] as const;
 
@@ -66,6 +67,7 @@ describe('관리자 명령 채널 라우팅', () => {
     expect(commandNames).toContain('delete');
     expect(commandNames).toContain('add-vacances');
     expect(commandNames).toContain('demo-daily-message');
+    expect(commandNames).toContain('demo-self-service-ui');
     expect(commandNames).not.toContain('approve-application');
     expect(commandNames).not.toContain('reject-application');
     expect(commandNames).not.toContain('register-cam');

--- a/src/test/command-localization.test.ts
+++ b/src/test/command-localization.test.ts
@@ -93,6 +93,14 @@ const commandSpecs = [
     options: [],
   },
   {
+    modulePath: '../commands/haruharu/demo-self-service-ui.js',
+    baseName: 'demo-self-service-ui',
+    koName: 'admin-demo-셀프서비스ui',
+    koDescription: '관리자가 테스트 채널에 셀프서비스 버튼 UI 데모 메시지를 게시합니다',
+    category: 'admin-demo',
+    options: [],
+  },
+  {
     modulePath: '../commands/haruharu/ping.js',
     baseName: 'ping',
     koName: 'admin-상태확인',

--- a/src/test/interactionCreate.test.ts
+++ b/src/test/interactionCreate.test.ts
@@ -77,4 +77,48 @@ describe('interactionCreate 이벤트', () => {
       ephemeral: true,
     });
   });
+
+  it('self-service 데모 버튼 interaction은 전용 라우터로 전달한다', async () => {
+    const buttonHandler = vi.fn();
+    vi.doMock('../services/selfServiceOnboardingDemo.js', () => ({
+      isSelfServiceDemoButtonCustomId: vi.fn().mockReturnValue(true),
+      isSelfServiceDemoModalCustomId: vi.fn().mockReturnValue(false),
+      handleSelfServiceDemoButtonInteraction: buttonHandler,
+      handleSelfServiceDemoModalSubmitInteraction: vi.fn(),
+    }));
+
+    const interaction = {
+      isChatInputCommand: () => false,
+      isButton: () => true,
+      isModalSubmit: () => false,
+      customId: 'self-service-demo:register:open',
+    };
+
+    const { event } = await import('../events/interactionCreate.js');
+    await event.execute(interaction as never);
+
+    expect(buttonHandler).toHaveBeenCalledWith(interaction);
+  });
+
+  it('self-service 데모 modal submit interaction은 전용 라우터로 전달한다', async () => {
+    const modalHandler = vi.fn();
+    vi.doMock('../services/selfServiceOnboardingDemo.js', () => ({
+      isSelfServiceDemoButtonCustomId: vi.fn().mockReturnValue(false),
+      isSelfServiceDemoModalCustomId: vi.fn().mockReturnValue(true),
+      handleSelfServiceDemoButtonInteraction: vi.fn(),
+      handleSelfServiceDemoModalSubmitInteraction: modalHandler,
+    }));
+
+    const interaction = {
+      isChatInputCommand: () => false,
+      isButton: () => false,
+      isModalSubmit: () => true,
+      customId: 'self-service-demo:register:submit',
+    };
+
+    const { event } = await import('../events/interactionCreate.js');
+    await event.execute(interaction as never);
+
+    expect(modalHandler).toHaveBeenCalledWith(interaction);
+  });
 });


### PR DESCRIPTION
## 연관된 이슈

- refs #108
- refs #103

## 작업 내용

- `testChannelId` 전용 관리자 커맨드 `/demo-self-service-ui`를 추가해 self-service 버튼 UI 샘플 메시지를 게시하도록 구현했습니다.
- `interactionCreate`를 확장해 샘플 button / modal submit interaction 을 라우팅하도록 구현했습니다.
- `register`, `apply-vacation`, `stop-wakeup`, `apply-cam`이 slash command 와 button/modal 샘플에서 같은 service / audit 경로를 재사용하도록 `selfServiceActions.ts`를 추가했습니다.
- `stop-wakeup` 샘플 경로에는 destructive action 방지용 확인 단계를 추가했습니다.
- `docs/PROJECT.md`, `README.md`, `AGENTS.md`를 `testChannelId` 샘플 범위에 맞춰 동기화했습니다.
- 승인된 범위 이탈 내역은 없습니다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
  B1[Before: operator uses only slash commands in testChannelId] --> B2[user manually enters register/apply-vacation/stop-wakeup/apply-cam]
  A1[After: operator runs demo-self-service-ui in testChannelId] --> A2[user clicks button]
  A2 --> A3{input needed}
  A3 -->|yes| A4[modal submit]
  A3 -->|no| A5[confirm or immediate action]
  A4 --> A6[shared selfServiceActions wrapper]
  A5 --> A6
  A6 --> A7[existing challengeSelfService or participationApplication]
  A7 --> A8[ephemeral response + testChannelId audit log]
```

## 이번 PR 범위

- 포함:
  - `testChannelId`에서 4개 사용자 흐름(`register`, `apply-vacation`, `stop-wakeup`, `apply-cam`)을 버튼 UI 샘플로 검증할 수 있는 경로
  - 기존 slash command 와 샘플 button/modal 이 같은 서비스/감사 로그를 재사용하도록 정리한 공통 래퍼
  - 관련 테스트와 문서 동기화
- 제외:
  - `#start-here`, `#time-start-here` 운영 채널에 실제 버튼 UI 배포
  - 운영용 안내 메시지 교체 전략 확정
  - `docs/USER_STORIES.md` 운영 플로우 전면 갱신
  - 실제 Discord 서버에서의 수동 UI/UX 확인 완료 처리

## 문서 영향

- 업데이트함:
  - `docs/PROJECT.md`: `testChannelId` 샘플 경로, 새 데모 커맨드, button/modal 라우팅, 공통 실행 래퍼 반영
  - `README.md`: `demo-self-service-ui`와 샘플 검증 목적 반영
  - `AGENTS.md`: `testChannelId` 데모 경로와 interaction 라우팅 반영
- 업데이트하지 않음:
  - `docs/USER_STORIES.md`: 이번 PR은 운영 `#start-here` / `#time-start-here` 사용자 흐름 전환이 아니라 `testChannelId` 샘플 단계라 운영 사용자 스토리 자체는 아직 바뀌지 않습니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- 완료조건
  - [x] `testChannelId`에서 관리자가 self-service 버튼 UI 샘플 메시지를 게시할 수 있다.
  - [x] 샘플 메시지에서 `기상 등록/수정`, `휴가 신청`, `기상 중단`, `캠스터디 참여` 4개 사용자 흐름을 버튼으로 시작할 수 있다.
  - [x] `기상 등록/수정` 샘플 버튼은 modal 로 `waketime`을 받고 기존 `/register` 검증/처리 로직을 재사용한다.
  - [x] `휴가 신청` 샘플 버튼은 modal 로 `date`를 받고 기존 `/apply-vacation` 검증/처리 로직을 재사용한다.
  - [x] `기상 중단` 샘플 버튼은 확인 단계 뒤에만 기존 `/stop-wakeup` 처리 로직을 실행한다.
  - [x] `캠스터디 참여` 샘플 버튼은 기존 `/apply-cam` 처리 로직을 재사용한다.
  - [x] button / modal 샘플 경로의 성공/실패 응답은 기존 self-service와 동일하게 `ephemeral`이며, 운영 확인용 결과가 `testChannelId`에도 남는다.
  - [x] 기존 `/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam` slash command 경로는 회귀 없이 계속 동작한다.
- red -> green 확인
  - [x] `interactionCreate`가 샘플 button / modal submit 을 라우팅하지 못하는 상태를 테스트로 먼저 고정하고 green 확인
  - [x] `기상 등록/수정` button -> modal submit 이 기존 `/register` 경로를 재사용하는 테스트를 red -> green 확인
  - [x] `기상 중단` 버튼이 첫 클릭에서 destructive action 을 실행하지 않고 확인 단계를 여는 테스트를 red -> green 확인
  - [x] `캠스터디 참여` 버튼과 `휴가 신청` modal 경로가 기존 service 호출을 재사용하는 테스트를 red -> green 확인
- 회귀 테스트 최종 통과
  - [x] 신규 `US-18-self-service-onboarding-demo.test.ts`
  - [x] `interactionCreate.test.ts`
  - [x] `admin-command-routing.test.ts`
  - [x] `command-localization.test.ts`
  - [x] 전체 `npm test`

## 추가된 테스트 명세

- `src/test/US-18-self-service-onboarding-demo.test.ts`
  - `demo-self-service-ui`가 테스트 채널에 버튼 UI 메시지를 게시하는지 검증
  - 데모 커맨드가 관리자 권한 비트를 사용하는지 검증
  - `stop-wakeup` 첫 클릭이 바로 destructive action 을 실행하지 않고 확인 단계를 여는지 검증
  - `stop-wakeup` 확인 버튼이 기존 self-service 중단 경로를 재사용하는지 검증
  - `register` modal submit 이 기존 register 처리 경로에 값을 전달하는지 검증
- 기존 테스트 확장
  - `interactionCreate.test.ts`: button / modal submit 라우팅 검증 추가
  - `admin-command-routing.test.ts`: 새 관리자 데모 커맨드 노출 확인
  - `command-localization.test.ts`: 새 데모 커맨드 ko localization 확인

## 검증항목 체크 결과

- [x] `npm run lint`
- [x] `npx prettier --check src docs README.md AGENTS.md`
- [x] `npm run build`
- [x] `npm test`
- [ ] 테스트 서버의 `testChannelId`에서 샘플 버튼 메시지를 게시하고 4개 흐름의 modal/confirm/UI 텍스트를 수동 확인
- [ ] button / modal 샘플 경로 성공/실패 결과가 사용자에게는 `ephemeral` 로 보이고 `#test` 감사 로그에는 남는지 수동 확인
- [ ] 기존 `/register`, `/stop-wakeup`, `/apply-vacation`, `/apply-cam` slash command가 샘플 도입 후에도 동일하게 동작하는지 수동 확인

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 있다면 PR 본문에 단일 `mermaid` 블록과 최상위 `Before: ...` / `After: ...` 박스를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 CI
  - `npm run lint`
  - `npx prettier --check src docs README.md AGENTS.md`
  - `npm run build`
  - `npm test`
- 실제 Discord UI/UX 검증은 PR 브랜치 기준으로 `testChannelId`에서 직접 확인 예정입니다.
