### PR TITLE
feat: 기상 self-service modal 허용 범위 안내 추가

### DIFF
--- a/src/services/selfServiceOnboarding.ts
+++ b/src/services/selfServiceOnboarding.ts
@@ -104,8 +104,8 @@ const buildRegisterModal = () =>
       new ActionRowBuilder<TextInputBuilder>().addComponents(
         new TextInputBuilder()
           .setCustomId(REGISTER_WAKETIME_INPUT_ID)
-          .setLabel('기상시간 (HHmm)')
-          .setPlaceholder('0700')
+          .setLabel('기상시간 (HHmm 또는 HH:mm)')
+          .setPlaceholder('05:00~09:00, 예: 0700 또는 07:00')
           .setRequired(true)
           .setStyle(TextInputStyle.Short),
       ),

--- a/src/services/selfServiceOnboardingDemo.ts
+++ b/src/services/selfServiceOnboardingDemo.ts
@@ -37,8 +37,8 @@ const buildRegisterModal = () =>
       new ActionRowBuilder<TextInputBuilder>().addComponents(
         new TextInputBuilder()
           .setCustomId(REGISTER_WAKETIME_INPUT_ID)
-          .setLabel('기상시간 (HHmm)')
-          .setPlaceholder('0700')
+          .setLabel('기상시간 (HHmm 또는 HH:mm)')
+          .setPlaceholder('05:00~09:00, 예: 0700 또는 07:00')
           .setRequired(true)
           .setStyle(TextInputStyle.Short),
       ),

--- a/src/test/US-18-self-service-onboarding-demo.test.ts
+++ b/src/test/US-18-self-service-onboarding-demo.test.ts
@@ -140,6 +140,33 @@ describe('US-18: self-service 온보딩 버튼 데모', () => {
     });
   });
 
+  it('기상 등록 버튼은 허용 시간 범위를 안내하는 modal을 연다', async () => {
+    vi.doMock('../services/selfServiceActions.js', () => ({
+      executeRegisterSelfService: vi.fn(),
+      executeApplyVacationSelfService: vi.fn(),
+      executeStopWakeupSelfService: vi.fn(),
+      executeApplyCamSelfService: vi.fn(),
+    }));
+
+    const { handleSelfServiceDemoButtonInteraction } = await import('../services/selfServiceOnboardingDemo.js');
+    const showModal = vi.fn();
+    const interaction = {
+      customId: 'self-service-demo:register:open',
+      channelId: 'valid-test-channel-id',
+      reply: vi.fn(),
+      showModal,
+    };
+
+    await handleSelfServiceDemoButtonInteraction(interaction as never);
+
+    expect(showModal).toHaveBeenCalledOnce();
+    const modalPayload = showModal.mock.calls[0]?.[0].toJSON();
+    const textInput = modalPayload.components[0].components[0];
+
+    expect(textInput.label).toBe('기상시간 (HHmm 또는 HH:mm)');
+    expect(textInput.placeholder).toBe('05:00~09:00, 예: 0700 또는 07:00');
+  });
+
   it('기상 등록 modal submit은 입력값을 기존 register 처리 경로로 전달한다', async () => {
     const executeRegisterSelfService = vi.fn().mockResolvedValue(undefined);
     vi.doMock('../services/selfServiceActions.js', () => ({

--- a/src/test/US-19-self-service-onboarding.test.ts
+++ b/src/test/US-19-self-service-onboarding.test.ts
@@ -140,6 +140,33 @@ describe('US-19: 운영 self-service 온보딩 UI', () => {
     );
   });
 
+  it('운영 기상 등록 버튼은 허용 시간 범위를 안내하는 modal을 연다', async () => {
+    vi.doMock('../services/selfServiceActions.js', () => ({
+      executeRegisterSelfService: vi.fn(),
+      executeApplyVacationSelfService: vi.fn(),
+      executeStopWakeupSelfService: vi.fn(),
+      executeApplyCamSelfService: vi.fn(),
+    }));
+
+    const { handleSelfServiceOnboardingButtonInteraction } = await import('../services/selfServiceOnboarding.js');
+    const showModal = vi.fn();
+    const interaction = {
+      customId: 'self-service-onboarding:register:open',
+      channelId: 'valid-time-start-here-channel-id',
+      reply: vi.fn(),
+      showModal,
+    };
+
+    await handleSelfServiceOnboardingButtonInteraction(interaction as never);
+
+    expect(showModal).toHaveBeenCalledOnce();
+    const modalPayload = showModal.mock.calls[0]?.[0].toJSON();
+    const textInput = modalPayload.components[0].components[0];
+
+    expect(textInput.label).toBe('기상시간 (HHmm 또는 HH:mm)');
+    expect(textInput.placeholder).toBe('05:00~09:00, 예: 0700 또는 07:00');
+  });
+
   it('운영 기상 등록 modal submit 은 기존 register 처리 경로를 재사용한다', async () => {
     const executeRegisterSelfService = vi.fn().mockResolvedValue(undefined);
     vi.doMock('../services/selfServiceActions.js', () => ({


### PR DESCRIPTION
## 연관된 이슈

- closes #119
- refs #119

## 작업 내용

- 운영 self-service `기상 등록/수정` modal의 입력 label/placeholder에 허용 기상시간 범위와 입력 예시를 추가했습니다.
- `demo-self-service-ui`의 동일 modal에도 같은 안내 copy를 반영했습니다.
- 운영/데모 두 경로 모두 modal open 시 안내 copy가 노출되는지 검증하는 테스트를 추가했습니다.

## 변경 흐름 (Mermaid)

- 구조, 실행 흐름, 데이터 흐름 변경이 없는 UI copy 보완이라 `mermaid`는 생략했습니다.

## 이번 PR 범위

- 포함: 운영 self-service register modal copy 조정, demo self-service register modal copy 조정, 두 modal open 테스트 추가
- 제외: waketime validation 정책 변경, `/register` 라우팅 변경, self-service 버튼 배치 변경, 문서 정책 변경

## 문서 영향

- 문서 변경 없음
- 이유: `docs/PROJECT.md`, `docs/USER_STORIES.md`, `README.md`에 이미 `HHmm`/`HH:mm` 형식과 `05:00~09:00` 허용 범위가 문서화되어 있습니다. 이번 변경은 기존 정책을 modal copy에 노출하는 UX 보완이며, 구조/실행 흐름/이벤트/DB 스키마 변화가 없습니다.
- `AGENTS.md`도 같은 이유로 업데이트하지 않았습니다.

## 이슈 완료 조건 / 회귀 테스트 체크

### 완료조건
- [x] 운영 `#start-here` 또는 `#time-start-here`에서 여는 `기상 등록/수정` modal에 허용 시간 범위를 제출 전에 확인할 수 있는 문구가 보인다.
- [x] `demo-self-service-ui`가 여는 `기상 등록/수정` modal에도 동일한 문구가 보인다.
- [x] 안내 문구는 현재 validation 정책과 일치하게 `05:00~09:00`, `HHmm` 또는 `HH:mm` 형식을 반영한다.
- [x] 기존 register submit 라우팅과 validation 실패/성공 동작은 그대로 유지된다.

### 완료조건별 red/green 검증 결과
- 운영 self-service modal 안내 문구: `src/test/US-19-self-service-onboarding.test.ts`에 modal open copy 검증을 추가했고, 구현 전 `label`이 `기상시간 (HHmm)`라 red를 확인한 뒤 구현 후 green을 확인했습니다.
- demo self-service modal 안내 문구: `src/test/US-18-self-service-onboarding-demo.test.ts`에 동일 검증을 추가했고, 구현 전 red 후 green을 확인했습니다.
- 기존 register submit 라우팅 유지: 같은 targeted test run에서 기존 submit 재사용 테스트가 함께 통과했습니다.

### 회귀 테스트 계획
- [x] 구현 전에 운영 self-service register modal을 여는 테스트를 보강해, 허용 시간 범위 안내 문구가 없으면 실패하도록 만들었다.
- [x] 구현 전에 demo self-service register modal 테스트를 보강해, 같은 안내 문구가 없으면 실패하도록 만들었다.
- [x] 구현 후 `src/test/US-19-self-service-onboarding.test.ts`와 `src/test/US-18-self-service-onboarding-demo.test.ts`가 green 이다.
- [x] 전체 `npm test`가 green 이다.

## 추가된 테스트 명세

- 운영 self-service `register:open` 버튼이 `기상시간 (HHmm 또는 HH:mm)` label과 `05:00~09:00, 예: 0700 또는 07:00` placeholder를 가진 modal을 여는지 검증합니다.
- demo self-service `register:open` 버튼이 같은 안내 copy를 가진 modal을 여는지 검증합니다.
- 기존 register modal submit이 기존 self-service register 처리 경로를 재사용하는 동작은 유지됩니다.

## 검증항목 체크 결과

- [x] `npm run lint`
- [x] `npx prettier --check src`
- [x] `npm run build`
- [x] `npm test`

## 승인으로 처리한 범위 이탈

- 없음

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 있다면 PR 본문에 단일 `mermaid` 블록과 최상위 `Before: ...` / `After: ...` 박스를 반영했나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 red 확인: 새 modal 안내 문구 테스트 2건이 기존 `기상시간 (HHmm)` label 때문에 실패함을 확인했습니다.
- 로컬 green 확인: targeted test 12건 통과, 전체 테스트 305건 통과를 확인했습니다.
