### PR TITLE
fix: 운영 기상등록 모달 안내 문구 정리

### DIFF
--- a/src/services/selfServiceOnboarding.ts
+++ b/src/services/selfServiceOnboarding.ts
@@ -104,8 +104,8 @@ const buildRegisterModal = () =>
       new ActionRowBuilder<TextInputBuilder>().addComponents(
         new TextInputBuilder()
           .setCustomId(REGISTER_WAKETIME_INPUT_ID)
-          .setLabel('기상시간 (HHmm 또는 HH:mm)')
-          .setPlaceholder('05:00~09:00, 예: 0700 또는 07:00')
+          .setLabel('기상시간 (HHmm, 05:00~09:00)')
+          .setPlaceholder('0700')
           .setRequired(true)
           .setStyle(TextInputStyle.Short),
       ),

--- a/src/test/US-19-self-service-onboarding.test.ts
+++ b/src/test/US-19-self-service-onboarding.test.ts
@@ -163,8 +163,8 @@ describe('US-19: 운영 self-service 온보딩 UI', () => {
     const modalPayload = showModal.mock.calls[0]?.[0].toJSON();
     const textInput = modalPayload.components[0].components[0];
 
-    expect(textInput.label).toBe('기상시간 (HHmm 또는 HH:mm)');
-    expect(textInput.placeholder).toBe('05:00~09:00, 예: 0700 또는 07:00');
+    expect(textInput.label).toBe('기상시간 (HHmm, 05:00~09:00)');
+    expect(textInput.placeholder).toBe('0700');
   });
 
   it('운영 기상 등록 modal submit 은 기존 register 처리 경로를 재사용한다', async () => {


### PR DESCRIPTION
## 연관된 이슈

- closes #125

## 작업 내용

- 운영 self-service 기상등록 modal의 label을 `기상시간 (HHmm, 05:00~09:00)`로 정리했습니다.
- 운영 self-service 기상등록 modal의 placeholder를 `0700`으로 단순화했습니다.
- 운영 onboarding modal copy를 검증하는 테스트 기대값을 새 문구에 맞게 갱신했습니다.

## 변경 흐름 (Mermaid)

- 구조, 실행 흐름, 데이터 흐름 변경은 없습니다. 기존 운영 self-service 버튼 -> modal 경로를 유지한 채 modal microcopy만 수정했습니다.

## 이번 PR 범위

- 포함: 운영 self-service 기상등록 modal copy 수정, 운영 modal 테스트 갱신
- 제외: `/register` 슬래시 커맨드 옵션 설명 변경, 데모 self-service copy 변경, 유효성 검사 로직 변경

## 문서 영향

- 문서 변경 없음
- 이유: 입력 형식과 허용 시간 범위 정책은 그대로이고, 운영 modal의 microcopy만 조정한 변경이기 때문입니다.

## 이슈 완료 조건 / 회귀 테스트 체크

- [x] 운영 self-service 기상 등록 modal label이 `기상시간 (HHmm, 05:00~09:00)`으로 노출됨
- [x] 운영 self-service 기상 등록 modal placeholder가 `0700`으로 노출됨
- [x] 관련 테스트가 변경된 문구 기준으로 green 임
- [x] 데모 self-service 경로는 이번 PR 범위에서 제외하고 기존 테스트 green 으로 유지됨
- [x] 구현 전 운영 modal 테스트 기대값을 바꿔 RED 확인 후 구현으로 GREEN 전환함

## 추가된 테스트 명세

- `src/test/US-19-self-service-onboarding.test.ts`
- 운영 self-service `기상 등록/수정` 버튼 클릭 시 노출되는 modal의 label/placeholder 문구를 검증합니다.
- 데모 경로는 `src/test/US-18-self-service-onboarding-demo.test.ts` 재실행으로 기존 동작 유지 여부를 확인했습니다.

## 체크리스트

- [x] PR 제목을 컨벤션에 맞게 작성했나요? (`feat: ...`, `fix: ...`)
- [x] 관련 이슈를 연결했나요?
- [x] 영향 범위에 맞는 테스트를 실행했나요?
- [x] 관련 이슈의 완료 조건과 회귀 테스트 항목을 이번 PR 기준으로 다시 확인했나요?
- [x] PR 본문에 추가/수정된 테스트 명세를 반영했나요?
- [x] 구조/흐름 변경이 없다면 그 이유를 PR 본문에 적었나요?
- [x] 문서 영향 분석을 했나요?
- [x] 필요한 문서를 업데이트했거나, 업데이트가 불필요한 이유를 PR 본문에 적었나요?
- [x] `AGENTS.md`와 관련 문서를 함께 업데이트했나요?
- [x] 브랜치 이름이 브랜치 컨벤션을 따르나요?

## 스크린샷 / 로그 / 추가 자료

- 로컬 검증: `npm run local:ci`
- 결과: lint, prettier check, build, test 통과 (`32 files, 311 tests passed`)
